### PR TITLE
persist options hash in call to extends or partial

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -29,7 +29,7 @@ module Rabl
     # Renders a partial hash based on another rabl template
     # partial("users/show", :object => @user)
     def partial(file, options={}, &block)
-      source = self.fetch_source(file)
+      source = self.fetch_source(file, options)
       self.object_to_hash(options[:object], :source => source, &block)
     end
 


### PR DESCRIPTION
I made a small edit to helpers to pass any options hash along to fetch source - in my case to override the view path, like this:
extends 'some_object', {:view_path=>'views/'}
