### PR TITLE
Rails 3.1.0.rc1 undefined method `copy_instance_variables_from' fixed

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -3,6 +3,7 @@ require 'rabl/helpers'
 require 'rabl/engine'
 require 'rabl/builder'
 require 'rabl/configuration'
+require 'rabl/railtie' if defined?(Rails) && Rails.version =~ /^3/
 
 # Rabl.register!
 module Rabl
@@ -33,7 +34,5 @@ if defined?(Padrino)
   require 'padrino-core'
   Padrino.after_load { Rabl.register! }
 elsif defined?(Rails) && Rails.version =~ /^2/
-  Rabl.register!
-elsif defined?(Rails) && Rails.version =~ /^3/
   Rabl.register!
 end

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -162,5 +162,10 @@ module Rabl
     def method_missing(name, *args, &block)
       @_scope.respond_to?(name) ? @_scope.send(name, *args, &block) : super
     end
+
+    def copy_instance_variables_from(object, exclude = []) #:nodoc:
+      vars = object.instance_variables.map(&:to_s) - exclude.map(&:to_s)
+      vars.each { |name| instance_variable_set(name, object.instance_variable_get(name)) }
+    end
   end
 end

--- a/lib/rabl/railtie.rb
+++ b/lib/rabl/railtie.rb
@@ -1,0 +1,10 @@
+module Rabl
+  class Railtie < Rails::Railtie
+
+    initializer "rabl.initialize" do |app|
+      ActiveSupport.on_load(:action_view) do
+        Rabl.register!
+      end
+    end
+  end
+end

--- a/lib/rabl/template.rb
+++ b/lib/rabl/template.rb
@@ -42,17 +42,14 @@ end
 
 # Rails 3.X Template
 if defined?(Rails) && Rails.version =~ /^3/
-  require 'action_view/base'
-  require 'action_view/template'
-
   module ActionView
     module Template::Handlers
-      class RablHandler < Template::Handler
-        include Compilable
+      class Rabl
 
+        class_attribute :default_format
         self.default_format = Mime::JSON
 
-        def compile(template) %{
+        def self.call(template) %{
           ::Rabl::Engine.new(#{template.source.inspect}).
             render(self, assigns.merge(local_assigns))
         } end
@@ -60,5 +57,5 @@ if defined?(Rails) && Rails.version =~ /^3/
     end
   end
 
-  ActionView::Template.register_template_handler :rabl, ActionView::TemplateHandlers::RablHandler
+  ActionView::Template.register_template_handler :rabl, ActionView::TemplateHandlers::Rabl
 end


### PR DESCRIPTION
Subj and added railtie to support rails 3 engines.
