### PR TITLE
Fix for issue #35 - template.source being empty

### DIFF
--- a/lib/rabl/template.rb
+++ b/lib/rabl/template.rb
@@ -52,10 +52,18 @@ if defined?(Rails) && Rails.version =~ /^3/
 
         self.default_format = Mime::JSON
 
-        def compile(template) %{
-          ::Rabl::Engine.new(#{File.read(template.identifier).inspect}).
-            render(self, assigns.merge(local_assigns))
-        } end
+        def compile(template)
+          source = if template.source.empty?
+            File.read(template.identifier)
+          else
+            template.source
+          end
+          
+          %{
+            ::Rabl::Engine.new(#{source.inspect}).
+              render(self, assigns.merge(local_assigns))
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
I have tested this out and it appears to fix the problems I
was having with https://github.com/nesquena/rabl/issues/35
The problem was that the template being used was correct, but
the source method, when evaluated, returned an empty string.
