### PR TITLE
Fix partial lookup problems in Padrino

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -64,9 +64,17 @@ module Rabl
     def fetch_source(file, options={})
       root_path = Rails.root if defined?(Rails)
       root_path = Padrino.root if defined?(Padrino)
-      view_path = options[:view_path] || File.join(root_path, "app/views/")
-      file_path = Dir[File.join(view_path, file + "*.rabl")].first
-      File.read(file_path) if file_path
+      if defined? Rails
+        view_path = options[:view_path] || File.join(root_path, "app/views/")
+        file_path = Dir[File.join(view_path, file + "*.rabl")].first
+      elsif defined? Padrino
+        # use Padrinos own template resolution mechanism
+        file_path, _ = @_scope.instance_eval { resolve_template(file) }
+        # Padrino chops the extension, stich it back on
+        file_path = File.join(@_scope.settings.views, (file_path.to_s + ".rabl"))
+      end
+      
+      File.read(file_path.to_s) if file_path
     end
   end
 end


### PR DESCRIPTION
If an application does not reside in "app/", partials were not found correctly. In more problematic cases, one application could find templates of another.

Trivial case:

```
    |
    \-backend
     |- app.rb
     \- views
      \-test
       \- foo.rabl
       \- bar.rabl
```

`foo` uses `bar` as a partial. The current template lookup mechanism would search for 'app/views/test/bar.rabl' and nothing else. If there were also an app under 'app/', this would also mean that templates from this app could be loaded by another app.

This fixes the problem by reusing Padrinos own template lookup mechanism, which works at application level.
