### PR TITLE
Configuration handling cleanup.

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -26,6 +26,11 @@ module Rabl
     def configuration
       @_configuration ||= Configuration.new
     end
+
+    # Resets the RABL configuration back to the defaults.
+    def reset_configuration_to_default
+      @_configuration = nil
+    end
   end
 end
 

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -4,7 +4,7 @@ module Rabl
     attr_accessor :include_json_root
     attr_accessor :include_xml_root
     attr_accessor :enable_json_callbacks
-    attr_accessor :json_engine
+    attr_writer   :json_engine
     attr_writer   :xml_options
 
     DEFAULT_XML_OPTIONS = { :dasherize  => true, :skip_types => false }
@@ -15,6 +15,10 @@ module Rabl
       @enable_json_callbacks = false
       @json_engine           = nil
       @xml_options           = {}
+    end
+
+    def json_engine
+      @json_engine || MultiJson.engine
     end
 
     # Allows config options to be read like a hash

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -9,10 +9,6 @@ module Rabl
     def initialize(source, options={})
       @_source = source
       @_options = options
-
-      if Rabl.configuration.json_engine
-        MultiJson.engine = Rabl.configuration.json_engine
-      end
     end
 
     # Renders the representation based on source, object, scope and locals
@@ -47,7 +43,7 @@ module Rabl
       include_root = Rabl.configuration.include_json_root
       options = options.reverse_merge(:root => include_root, :child_root => include_root)
       result = @_collection_name ? { @_collection_name => to_hash(options) } : to_hash(options)
-      format_json MultiJson.encode(result)
+      format_json Rabl.configuration.json_engine.encode(result)
     end
 
     # Returns an xml representation of the data object

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -9,16 +9,17 @@ context "Rabl::Configuration" do
     asserts(:include_json_root).equals true
     asserts(:include_xml_root).equals false
     asserts(:enable_json_callbacks).equals false
-    asserts(:json_engine).equals nil
+    asserts(:json_engine).equals MultiJson.engine
   end
 
   context "with configuration" do
+    class CustomEncodeEngine; end
     setup do
       Rabl.configure do |config|
         config.include_json_root     = false
         config.include_xml_root      = true
         config.enable_json_callbacks = true
-        config.json_engine           = :yajl
+        config.json_engine           = CustomEncodeEngine
       end
       Rabl.configuration
     end
@@ -26,13 +27,10 @@ context "Rabl::Configuration" do
     asserts(:include_json_root).equals false
     asserts(:include_xml_root).equals true
     asserts(:enable_json_callbacks).equals true
-    asserts(:json_engine).equals :yajl
+    asserts(:json_engine).equals CustomEncodeEngine
 
     teardown do
-      Rabl.configure do |config|
-        config.json_engine = MultiJson.default_engine
-      end
+      Rabl.reset_configuration_to_default
     end
   end
-
 end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -161,6 +161,10 @@ context "Rabl::Engine" do
         template.render(scope).split('').sort
       end.equals "{\"user\":{\"name\":\"leo\",\"city\":\"LA\",\"age\":12}}".split('').sort
     end
+
+    teardown do
+      Rabl.reset_configuration_to_default
+    end
   end
 
   context "with json_engine" do
@@ -186,9 +190,7 @@ context "Rabl::Engine" do
     end.equals 42
 
     teardown do
-      Rabl.configure do |config|
-        config.json_engine = MultiJson.default_engine
-      end
+      Rabl.reset_configuration_to_default
     end
   end
 
@@ -335,6 +337,10 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA', :age => 12)
         template.render(scope).split('').sort
       end.equals "{\"name\":\"leo\",\"city\":\"LA\",\"age\":12}".split('').sort
+    end
+
+    teardown do
+      Rabl.reset_configuration_to_default
     end
   end
 end


### PR DESCRIPTION
Before I started chasing down how to do something else with RABL that I'll be getting to soon, I ran the tests as they existed currently. They failed. Turns out, my tests likely run in a different order than when you run them which was causing failures.

Instead of just fixing the missing teardown which would have fixed the tests, I decided to clean things up a little along the way. The real solution should really be to use dependency injection for the configuration wherever it's used so that the tests don't ever have to touch global state to test various options, but I did not want to go this far with my cleanup.

My cleanup had two basic goals:
1) Pull knowledge of how to reset to the default configuration out of the tests themselves.
2) Don't unexpectedly change `MultiJson.engine`. It is very possible that someone using RABL will independently want to change the engine and RABL shouldn't unexpectedly change it to something else.
