### PR TITLE
error in docs (i think)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ get "/posts", :provides => [:json, :xml] do
 end
 ```
 
-Then we can create the following RABL template to express the API output of `@posts`:
+Then we can create the following RABL json template to express the API output of `@posts`:
 
 ```ruby
-# app/views/posts/index.rabl
+# app/views/posts/index.json.rabl
 collection @posts
 attributes :id, :title, :subject
 child(:user) { attributes :full_name }


### PR DESCRIPTION
Hi there...

I just updated the docs to explicitly name "json" in the example.  I'm using padrino and i could not get blah.rabl to work unless i added blah.json.rabl in.  If this is my mistake please let me know and sorry for wasting your time! :)

thanks
