### PR TITLE
Adds optional msgpack serialization format to Rabl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ RABL is intended to require little to no configuration to get working. This is t
 Rabl.configure do |config|
   # Commented as these are the defaults
   # config.json_engine = nil # Any multi\_json engines
+  # config.msgpack_engine = nil # Defaults to ::MessagePack
   # config.include_json_root = true
+  # config.include_msgpack_root = true
   # config.include_xml_root  = false
   # config.enable_json_callbacks = false
   # config.xml_options = { :dasherize  => true, :skip_types => false }
@@ -104,6 +106,32 @@ gem 'yajl-ruby', :require => "yajl"
 ```
 
 and RABL will automatically start using that engine for encoding your JSON responses!
+
+### Message Pack ###
+
+Rabl also includes optional support for [Message Pack](http://www.msgpack.org/) serialization format using the [msgpack gem](https://rubygems.org/gems/msgpack).
+To enable, include the msgpack gem in your project's Gemfile. Then use Rabl as normal with the `msgpack` format (akin to json and xml formats).
+
+```ruby
+# Gemfile
+gem 'msgpack', '~> 0.4.5'
+```
+
+One can additionally use a custom Message Pack implementation by setting the Rabl `msgpack_engine` configuration attribute. This custom message pack engine must conform to the MessagePack#pack method signature.
+
+```ruby
+class CustomEncodeEngine
+  def self.pack string
+    # Custom Encoding by your own engine.
+  end
+end
+
+Rabl.configure do |config|
+  config.msgpack_engine = CustomEncodeEngine
+end
+```
+
+*NOTE*: Attempting to render the msgpack format without either including the msgpack gem or setting a `msgpack_engine` will cause an exception to be raised.
 
 ## Usage ##
 

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -1,25 +1,41 @@
+# We load the msgpack library if it is available.
+begin
+  require 'msgpack'
+rescue LoadError
+end
+
 module Rabl
   # Rabl.host
   class Configuration
     attr_accessor :include_json_root
+    attr_accessor :include_msgpack_root
     attr_accessor :include_xml_root
     attr_accessor :enable_json_callbacks
     attr_writer   :json_engine
+    attr_writer   :msgpack_engine
     attr_writer   :xml_options
 
     DEFAULT_XML_OPTIONS = { :dasherize  => true, :skip_types => false }
 
     def initialize
       @include_json_root     = true
+      @include_msgpack_root  = true
       @include_xml_root      = false
       @enable_json_callbacks = false
       @json_engine           = nil
+      @msgpack_engine        = nil
       @xml_options           = {}
     end
 
     # Returns the multi_json engine for use with RABL
     def json_engine
       @json_engine || MultiJson.engine
+    end
+
+    ##
+    # @return the MessagePack encoder/engine to use.
+    def msgpack_engine
+      @msgpack_engine || ::MessagePack
     end
 
     # Allows config options to be read like a hash

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -46,6 +46,15 @@ module Rabl
       format_json result
     end
 
+    # Returns a msgpack representation of the data object
+    # to_msgpack(:root => true)
+    def to_msgpack(options={})
+      include_root = Rabl.configuration.include_msgpack_root
+      options = options.reverse_merge(:root => include_root, :child_root => include_root)
+      result = @_collection_name ? { @_collection_name => to_hash(options) } : to_hash(options)
+      Rabl.configuration.msgpack_engine.pack result
+    end
+
     # Returns an xml representation of the data object
     # to_xml(:root => true)
     def to_xml(options={})

--- a/rabl.gemspec
+++ b/rabl.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'tilt'
   s.add_development_dependency 'bson_ext'
   s.add_development_dependency 'yajl-ruby'
+  s.add_development_dependency 'msgpack', '~> 0.4.5'
 end

--- a/test/msgpack_engine_test.rb
+++ b/test/msgpack_engine_test.rb
@@ -1,0 +1,333 @@
+require File.expand_path('../teststrap', __FILE__)
+require File.expand_path('../../lib/rabl', __FILE__)
+require File.expand_path('../../lib/rabl/template', __FILE__)
+require File.expand_path('../models/user', __FILE__)
+
+context "Rabl::Engine" do
+
+  helper(:rabl) { |t| RablTemplate.new("code", :format => 'msgpack') { t } }
+
+  context "with msgpack defaults" do
+    setup do
+      Rabl.configure do |config|
+        # Comment this line out because include_msgpack_root is default.
+        #config.include_msgpack_root = true
+      end
+    end
+
+    context "#object" do
+
+      asserts "that it sets data source" do
+        template = rabl %q{
+          object @user
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new
+        template.render(scope)
+      end.matches "\x81\xA4user\x80"
+
+      asserts "that it can set root node" do
+        template = rabl %q{
+          object @user => :person
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new
+        template.render(scope)
+      end.equals "\x81\xA6person\x80"
+    end
+
+    context "#collection" do
+
+      asserts "that it sets object to be casted as a simple array" do
+        template = rabl %{
+          collection @users
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new, User.new]
+        template.render(scope)
+      end.equals "\x92\x81\xA4user\x80\x81\xA4user\x80"
+
+      asserts "that it sets root node for objects" do
+        template = rabl %{
+          collection @users => :person
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new, User.new]
+        template.render(scope)
+      end.equals "\x81\xA6person\x92\x81\xA6person\x80\x81\xA6person\x80"
+
+    end
+
+    context "#attribute" do
+
+      asserts "that it adds an attribute or method to be included in output" do
+        template = rabl %{
+          object @user
+          attribute :name
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine')
+        template.render(scope)
+      end.equals "\x81\xA4user\x81\xA4name\xA6irvine"
+
+      asserts "that it can add attribute under a different key name through :as" do
+        template = rabl %{
+          object @user
+          attribute :name, :as => 'city'
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine')
+        template.render(scope)
+      end.equals "\x81\xA4user\x81\xA4city\xA6irvine"
+
+      asserts "that it can add attribute under a different key name through hash" do
+        template = rabl %{
+          object @user
+          attribute :name => :city
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine')
+        template.render(scope)
+      end.equals "\x81\xA4user\x81\xA4city\xA6irvine"
+
+    end
+
+    context "#code" do
+
+      asserts "that it can create an arbitraty code node" do
+        template = rabl %{
+          code(:foo) { 'bar' }
+        }
+        template.render(Object.new)
+      end.equals "\x81\xA3foo\xA3bar"
+
+      asserts "that it can be passed conditionals" do
+        template = rabl %{
+          code(:foo, :if => lambda { |i| false }) { 'bar' }
+        }
+        template.render(Object.new)
+      end.equals "\x80"
+
+    end
+
+    context "#child" do
+
+      asserts "that it can create a child node" do
+        template = rabl %{
+          object @user
+          attribute :name
+          child(@user) { attribute :city }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA')
+        template.render(scope)
+      end.equals "\x81\xA4user\x82\xA4name\xA3leo\xA4user\x81\xA4city\xA2LA"
+
+      asserts "that it can create a child node with different key" do
+        template = rabl %{
+          object @user
+          attribute :name
+          child(@user => :person) { attribute :city }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA')
+        template.render(scope)
+
+      end.equals "\x81\xA4user\x82\xA4name\xA3leo\xA6person\x81\xA4city\xA2LA"
+    end
+
+    context "#glue" do
+
+      asserts "that it glues data from a child node" do
+        template = rabl %{
+          object @user
+          attribute :name
+          glue(@user) { attribute :city }
+          glue(@user) { attribute :age  }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA', :age => 12)
+        template.render(scope)
+      end.equals "\x81\xA4user\x83\xA4name\xA3leo\xA4city\xA2LA\xA3age\f"
+    end
+
+    teardown do
+      Rabl.reset_configuration!
+    end
+  end
+
+  context "with msgpack_engine" do
+    setup do
+      class CustomEncodeEngine
+        def self.pack string
+          42
+        end
+      end
+
+      Rabl.configure do |config|
+        config.msgpack_engine = CustomEncodeEngine
+      end
+    end
+
+    asserts 'that it returns process by custom to_json' do
+      template = rabl %q{
+        object @user
+      }
+      scope = Object.new
+      scope.instance_variable_set :@user, User.new
+      template.render(scope)
+    end.equals 42
+
+    teardown do
+      Rabl.reset_configuration!
+    end
+  end
+
+  context "without msgpack root" do
+    setup do
+      Rabl.configure do |config|
+        config.include_msgpack_root = false
+      end
+    end
+
+    context "#object" do
+
+      asserts "that it sets data source" do
+        template = rabl %q{
+          object @user
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new
+        template.render(scope)
+      end.matches "\x80"
+
+      asserts "that it can set root node" do
+        template = rabl %q{
+          object @user => :person
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new
+        template.render(scope)
+      end.equals "\x80"
+    end
+
+    context "#collection" do
+
+      asserts "that it sets object to be casted as a simple array" do
+        template = rabl %{
+          collection @users
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new, User.new]
+        template.render(scope)
+      end.equals "\x92\x80\x80"
+
+      asserts "that it sets root node for objects" do
+        template = rabl %{
+          collection @users => :person
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new, User.new]
+        template.render(scope)
+      end.equals "\x81\xA6person\x92\x80\x80"
+
+    end
+
+    context "#attribute" do
+
+      asserts "that it adds an attribute or method to be included in output" do
+        template = rabl %{
+          object @user
+          attribute :name
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine')
+        template.render(scope)
+      end.equals "\x81\xA4name\xA6irvine"
+
+      asserts "that it can add attribute under a different key name through :as" do
+        template = rabl %{
+          object @user
+          attribute :name, :as => 'city'
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine')
+        template.render(scope)
+      end.equals "\x81\xA4city\xA6irvine"
+
+      asserts "that it can add attribute under a different key name through hash" do
+        template = rabl %{
+          object @user
+          attribute :name => :city
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine')
+        template.render(scope)
+      end.equals "\x81\xA4city\xA6irvine"
+
+    end
+
+    context "#code" do
+
+      asserts "that it can create an arbitraty code node" do
+        template = rabl %{
+          code(:foo) { 'bar' }
+        }
+        template.render(Object.new)
+      end.equals "\x81\xA3foo\xA3bar"
+
+      asserts "that it can be passed conditionals" do
+        template = rabl %{
+          code(:foo, :if => lambda { |i| false }) { 'bar' }
+        }
+        template.render(Object.new)
+      end.equals "\x80"
+
+    end
+
+    context "#child" do
+
+      asserts "that it can create a child node" do
+        template = rabl %{
+          object @user
+          attribute :name
+          child(@user) { attribute :city }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA')
+        template.render(scope)
+      end.equals "\x82\xA4name\xA3leo\xA4user\x81\xA4city\xA2LA"
+
+      asserts "that it can create a child node with different key" do
+        template = rabl %{
+          object @user
+          attribute :name
+          child(@user => :person) { attribute :city }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA')
+        template.render(scope)
+
+      end.equals "\x82\xA4name\xA3leo\xA6person\x81\xA4city\xA2LA"
+    end
+
+    context "#glue" do
+
+      asserts "that it glues data from a child node" do
+        template = rabl %{
+          object @user
+          attribute :name
+          glue(@user) { attribute :city }
+          glue(@user) { attribute :age  }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA', :age => 12)
+        template.render(scope)
+      end.equals "\x83\xA4name\xA3leo\xA4city\xA2LA\xA3age\f"
+    end
+
+    teardown do
+      Rabl.reset_configuration!
+    end
+  end
+end


### PR DESCRIPTION
Details
- Fixes #68 (nesquena/rabl issues tracker)
- Message Pack: http://www.msgpack.org/
- Defaults to using the Ruby msgpack gem: http://rubygems.org/gems/msgpack
- Adds Rabl configuration option `include_msgpack_root` which has same semantics as include_json_root.
- Adds Rabl configuration option `msgpack_engine` which has similar semantics as json_engine.
- Adds whole test suite that is essentially a clone of engine_test.rb, but with proper msgpack expected values.
  Note that I converted the JSON expected values to their msgpack equivalent in this process.
- Updated README.md to reflect the msgpack changes.
