### PR TITLE
Support Hash syntax for node/code

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -61,7 +61,11 @@ module Rabl
     # code(:foo) { "bar" }
     # code(:foo, :if => lambda { |m| m.foo.present? }) { "bar" }
     def code(name, options={}, &block)
-      @_result[name] = block.call(@_object) if resolve_condition(options)
+      if name.is_a? Hash
+        @_result.merge! name
+      else
+        @_result[name] = block.call(@_object) if resolve_condition(options)        
+      end
     end
     alias_method :node, :code
 

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -91,6 +91,11 @@ context "Rabl::Builder" do
       topic.code(:foo) { "bar" }
       get_result(topic)
     end.equivalent_to({:foo => 'bar'})
+    
+    asserts "that it has node :foo setted in hash style" do
+      topic.code :foo => 'bar'
+      get_result(topic)
+    end.equivalent_to({:foo => 'bar'})
 
     asserts "that using object it has node :boo" do
       topic.code(:baz) { |u| u.city }

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -111,6 +111,13 @@ context "Rabl::Engine" do
         }
         template.render(Object.new)
       end.equals "{\"foo\":\"bar\"}"
+      
+      asserts "that it can create an arbitraty code node in hash syntax" do
+        template = rabl %{
+          code :foo => 'bar'
+        }
+        template.render(Object.new)
+      end.equals "{\"foo\":\"bar\"}"
 
       asserts "that it can be passed conditionals" do
         template = rabl %{


### PR DESCRIPTION
Allow to do something like that:

``` ruby
node :children => []
```

or

``` ruby
object @node
code :children => @node.children.map {...}
```

I think it's useful. Hope it's suitable for rabl.
