### PR TITLE
don't raise when called from a nested controller

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -127,9 +127,10 @@ module Rabl
     # Returns a guess at the default object for this template
     # default_object => @user
     def default_object
-      @_scope.respond_to?(:controller) ?
-        instance_variable_get("@#{@_scope.controller.controller_name}") :
-        nil
+      if @_scope.respond_to?(:controller)
+        full_name = @_scope.controller.controller_name
+        instance_variable_get("@#{ full_name.split("::").last }")
+      end
     end
 
     # Returns a guess at the format in this scope

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -45,6 +45,12 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@user, User.new
         template.render(scope)
       end.equals "{\"person\":{}}"
+
+      asserts "that it works with nested controllers" do
+        template = rabl ""
+        scope = NestedScope::User.new
+        template.render(scope)
+      end.matches "{}"
     end
 
     context "#collection" do

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -7,3 +7,10 @@ class User
   field :city, :type => String,  :default => 'irvine'
   field :age,  :type => Integer, :default => 24
 end
+
+module NestedScope
+  class User
+    def controller; self; end
+    def controller_name; self.class.name; end
+  end
+end


### PR DESCRIPTION
before this patch, calling render from a nested controller (Foo::Bar::BazController) would raise an error when instance_variable_get was called, a la

`@foo::bar::baz` is not allowed as an instance variable name

tested using Rails 3.0.9
