### PR TITLE
Show template names in stack trace

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -17,7 +17,11 @@ module Rabl
       @_options[:scope] = @_scope
       @_options[:format] ||= self.request_format
       @_data = locals[:object] || self.default_object
-      instance_eval(@_source) if @_source.present?
+      if @_options[:source_location]
+        instance_eval(@_source, @_options[:source_location]) if @_source.present?
+      else
+        instance_eval(@_source) if @_source.present?
+      end
       instance_eval(&block) if block_given?
       self.send("to_" + @_options[:format].to_s)
     end

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -29,8 +29,8 @@ module Rabl
     # Renders a partial hash based on another rabl template
     # partial("users/show", :object => @user)
     def partial(file, options={}, &block)
-      source = self.fetch_source(file, options)
-      self.object_to_hash(options[:object], :source => source, &block)
+      source, location = self.fetch_source(file, options)
+      self.object_to_hash(options[:object], :source => source, :source_location => location, &block)
     end
 
     # Returns a hash based representation of any data object given ejs template block
@@ -38,7 +38,7 @@ module Rabl
     # object_to_hash(@user, :source => "...") { attribute :full_name } => { ... }
     def object_to_hash(object, options={}, &block)
       return object unless is_object?(object)
-      engine_options = { :format => "hash", :root => (options[:root] || false) }
+      engine_options = { :format => "hash", :root => (options[:root] || false), :source_location => options[:source_location]}
       Rabl::Engine.new(options[:source], engine_options).render(@_scope, :object => object, &block)
     end
 
@@ -74,7 +74,12 @@ module Rabl
         # Padrino chops the extension, stitch it back on
         file_path = File.join(@_scope.settings.views, (file_path.to_s + ".rabl"))
       end
-      File.read(file_path.to_s) if file_path
+      
+      if file_path
+        return File.read(file_path.to_s), file_path.to_s
+      else 
+        nil
+      end
     end
   end
 end

--- a/lib/rabl/template.rb
+++ b/lib/rabl/template.rb
@@ -7,7 +7,7 @@ if defined?(Tilt)
     end
 
     def prepare
-      options = @options.merge(:format => @options[:format])
+      options = @options.merge(:format => @options[:format], :source_location => file)
       @engine = ::Rabl::Engine.new(data, options)
     end
 

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -8,24 +8,24 @@ end
 
 context "Rabl::Helpers" do
   context "fetch_source" do
+    helper(:tmp_path) { @tmp_path ||= Pathname.new(Dir.mktmpdir) }
+    
     setup do
       Rails = stub(Class.new)
-      Dir.mktmpdir do |dir|
-        tmp_path = Pathname.new(dir)
-        Rails.root.returns(tmp_path)
-        File.open(tmp_path + "test.json.rabl", "w") do |f|
-          f.puts "content"
-        end
-        File.open(tmp_path + "test_v1.json.rabl", "w") do |f|
-          f.puts "content_v1"
-        end
-        FileUtils.touch tmp_path + "test_v2.json.rabl"
-        [TestHelper.new.fetch_source('test', :view_path => tmp_path.to_s),
-         TestHelper.new.fetch_source('test_v1', :view_path => tmp_path.to_s)]
+      Rails.root.returns(tmp_path)
+      File.open(tmp_path + "test.json.rabl", "w") do |f|
+        f.puts "content"
       end
+      File.open(tmp_path + "test_v1.json.rabl", "w") do |f|
+        f.puts "content_v1"
+      end
+      FileUtils.touch tmp_path + "test_v2.json.rabl"
+      [TestHelper.new.fetch_source('test', :view_path => tmp_path.to_s),
+       TestHelper.new.fetch_source('test_v1', :view_path => tmp_path.to_s)]
     end
-    asserts(:first).equals "content\n"
-    asserts(:last).equals "content_v1\n"
+    
+    asserts(:first).equals {["content\n", (tmp_path + "test.json.rabl").to_s ]}
+    asserts(:last).equals {["content_v1\n", (tmp_path + "test_v1.json.rabl").to_s ]}
     teardown { Object.send(:remove_const, :Rails) }
   end
 end


### PR DESCRIPTION
This changes a few internals to allow stack traces to show the template name instead of `eval`. Most notably, it changes the behavior of the tilt engine and of fetch_source. I hope I caught all important cases where they are used. Except for the internal API of fetch_source, it should be backwards compatible.
