### PR TITLE
Fixed collection name for empty collections.

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -16,9 +16,16 @@ module Rabl
     def data_name(data)
       return nil unless data # nil or false
       return data.values.first if data.is_a?(Hash) # @user => :user
-      data = @_object.send(data) if data.is_a?(Symbol) && @_object # :address
+      if data.is_a?(Symbol)
+        symbolString = data.to_s.downcase
+        data = @_object.send(data) if @_object # :address
+      end
       if data.respond_to?(:first)
-        data_name(data.first).pluralize if data.first.present?
+        if data.first.present?
+          data_name(data.first).pluralize
+        else
+          symbolString
+        end
       else # actual data object
         object_name = @_collection_name.to_s.singularize if defined? @_collection_name
         object_name ||= data.class.respond_to?(:model_name) ? data.class.model_name.element : data.class.to_s.downcase


### PR DESCRIPTION
I didn't want to change too much here, since I'm not sure of the original motivations, so this is the minimal change to fix the problem.

Possibly a better change would be to just take the symbol name in all cases? I would think this would be the least surprising option. 
