### PR TITLE
Use code block with collections (relating to issue #120)

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -25,8 +25,8 @@ module Rabl
         attribute(attribute, :as => name)
       end if @options.has_key?(:attributes)
       # Code
-      @options[:code].each_pair do |name, settings|
-        code(name, settings[:options], &settings[:block])
+      @options[:code].each do |settings|
+        code(settings[:name], settings[:options], &settings[:block])
       end if @options.has_key?(:code)
       # Children
       @options[:child].each do |settings|
@@ -61,7 +61,13 @@ module Rabl
     # code(:foo) { "bar" }
     # code(:foo, :if => lambda { |m| m.foo.present? }) { "bar" }
     def code(name, options={}, &block)
-      @_result[name] = block.call(@_object) if resolve_condition(options)
+      return unless resolve_condition(options)
+      result = block.call(@_object)
+      if name.present?
+        @_result[name] = result
+      else
+        @_result.merge!(result) if result
+      end
     end
     alias_method :node, :code
 

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -99,9 +99,9 @@ module Rabl
     # Creates an arbitrary code node that is included in the json output
     # code(:foo) { "bar" }
     # code(:foo, :if => lambda { ... }) { "bar" }
-    def code(name, options={}, &block)
-      @_options[:code] ||= {}
-      @_options[:code][name] = { :options => options, :block => block }
+    def code(name = nil, options={}, &block)
+      @_options[:code] ||= []
+      @_options[:code] << { :name => name, :options => options, :block => block }
     end
     alias_method :node, :code
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -146,6 +146,18 @@ context "Rabl::Engine" do
         }
         template.render(Object.new)
       end.equals "{}"
+      
+      asserts "that it can merge the result with a collection element given no name" do
+        template = rabl %{
+          collection @users
+          code do |user|
+            {:name => user.name}
+          end
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'a'), User.new(:name => 'b')]
+        template.render(scope)
+      end.equals "[{\"user\":{\"name\":\"a\"}},{\"user\":{\"name\":\"b\"}}]"
 
     end
 


### PR DESCRIPTION
This patch makes the name supplied to the code method optional, allowing it to be used with collections. For example:

collection @users
code do |user|
  {:name => "user - #{user.name}"}
end

Each element in the collection has a name attribute with the calculated value. Or:

collection @users
code do |user|
  partial("users/#{user.sti_type}", :object => user)
end

Code without a name argument expects the associated block to return a hash.
