### PR TITLE
Updated README with layouts information

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Note that RABL can be nested arbitrarily deep within child nodes to allow for th
 ### Advanced Usage ###
 
  * Rendering JSON for a tree structure using RABL: https://github.com/nesquena/rabl/issues/70
+ * Layouts (erb, haml and rabl) in RABL: https://github.com/nesquena/rabl/wiki/Using-Layouts
 
 ## Issues ##
 


### PR DESCRIPTION
I wrote here https://github.com/nesquena/rabl/issues/87 about Rabl–templates and now I realize, how to use them. I've added this info to wiki and to README. 

So, now we can use `native` Rabl layouts. I think everybody already use this, but this was not documented.
