### PR TITLE
Added caching of partials (views), which improves performance.

### DIFF
--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -27,6 +27,7 @@ module Rabl
       @json_engine           = nil
       @msgpack_engine        = nil
       @xml_options           = {}
+      @cache                 = {}
     end
 
     # @param [Symbol, String, #encode] engine_name The name of a JSON engine,
@@ -57,6 +58,19 @@ module Rabl
     # Returns merged default and inputted xml options
     def default_xml_options
       @_default_xml_options ||= @xml_options.reverse_merge(DEFAULT_XML_OPTIONS)
+    end
+
+    def cache=(key, value)
+      @cache[key] = value
+    end
+
+    # Used to store partials in cache, to avoid reading from disk.
+    def cache
+      @cache ||= {}
+    end
+
+    def clear_cache
+      @cache = {}
     end
 
     private

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -32,7 +32,10 @@ module Rabl
     # options can have :view_path, :child_root, :root
     def partial(file, options={}, &block)
       object, view_path = options.delete(:object), options.delete(:view_path)
-      source, location = self.fetch_source(file, :view_path => view_path)
+      if !template = Rabl.configuration.cache[file]
+        template = Rabl.configuration.cache[file] = self.fetch_source(file, :view_path => view_path)
+      end
+      source, location = template
       engine_options = options.merge(:source => source, :source_location => location)
       self.object_to_hash(object, engine_options, &block)
     end


### PR DESCRIPTION
This deals with issue #167
### Turns:

``` console
  DEBUG - TEMPLATE (0.0001ms) /v1/users/index.json
  DEBUG - User Load (15.2ms)  SELECT `user`.* FROM `user` LIMIT 500
  DEBUG - TEMPLATE (0.0003ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0002ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0004ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0003ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0006ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0009ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0003ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0025ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0001ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0002ms) /v1/users/show.json
  DEBUG - TEMPLATE (0.0009ms) /v1/users/show.json
  # ...
  DEBUG -      GET (1.5957ms) /v1/users.json - 200 OK
```
### Into:

``` console
  DEBUG - User Load (11.3ms)  SELECT `user`.* FROM `user` LIMIT 500
  DEBUG - TEMPLATE (0.0003ms) /v1/users/show.json
  DEBUG -      GET (0.3739ms) /v1/users.json - 200 OK
```

You can clear out the cache by simply calling:

``` ruby
Rabl.configuration.clear_cache
```

It also fixes an issue with [Padrino](http://www.padrinorb.com/) where if you're using some gems that define `Rails` it would cause it to try and `fetch_source` the rails way instead of the padrino way causing it to fail.
