### PR TITLE
Do not include object root nodes on collection if specified

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -37,8 +37,11 @@ module Rabl
         options[:root_name] = root_name if options[:root]
         builder.build(data, options)
       elsif is_collection?(data) # collection @users
-        options[:root_name] = object_root_name if object_root_name
-        options[:root_name] ||= root_name.to_s.singularize if options[:root]
+        if object_root_name.nil?
+          options[:root_name] = root_name.to_s.singularize if options[:root]
+        else
+          options[:root_name] = object_root_name
+        end
         data.map { |object| builder.build(object, options) }
       end
     end
@@ -102,7 +105,7 @@ module Rabl
     def collection(data, options={})
       @_collection_name = options[:root] if options[:root]
       @_collection_name ||= data.values.first if data.respond_to?(:each_pair)
-      @_object_root_name = options[:object_root] if options[:object_root]
+      @_object_root_name = options[:object_root] if options.has_key?(:object_root)
       self.object(data_object(data).to_a) if data
     end
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -77,15 +77,23 @@ context "Rabl::Engine" do
         template.render(scope)
       end.equals "[{\"user\":{}},{\"user\":{}}]"
 
-      # TODO fix this test
-      # asserts "that it sets root node for objects" do
-      #   template = rabl %{
-      #     collection @users => :people
-      #   }
-      #   scope = Object.new
-      #   scope.instance_variable_set :@users, [User.new, User.new]
-      #   template.render(scope)
-      # end.equals "{\"people\":[{\"person\":{}},{\"person\":{}}]}"
+      asserts "that it sets root node for objects" do
+       template = rabl %{
+         collection @users => :users
+       }
+       scope = Object.new
+       scope.instance_variable_set :@users, [User.new, User.new]
+       template.render(scope)
+      end.equals "{\"users\":[{\"user\":{}},{\"user\":{}}]}"
+
+      asserts "that it doesn't set root node for objects when specified" do
+       template = rabl %{
+         collection @users, :root => :users, :object_root => false
+       }
+       scope = Object.new
+       scope.instance_variable_set :@users, [User.new, User.new]
+       template.render(scope)
+      end.equals "{\"users\":[{},{}]}"
 
       asserts "that it can use non-ORM objects" do
         template = rabl %q{


### PR DESCRIPTION
Quick fix to not include object root nodes on a collection if the user specifies `:object_root => false`:

Example:

```
collection :users, :root => :users, :object_root => false
```

would result in

```
{ "users": [ {"key":value}, {"key":value}, ... ] }
```

One weird thing: If you specify nil, it will pull the object_root_name from the collection name rather than omitting it. I wasn't sure how you'd want this to work since the Ruby world usually treats `nil` and `false` synonymously since they both evaluate to false.
