### PR TITLE
adding include_child_root configuration option for child method

### DIFF
--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -23,6 +23,7 @@ module Rabl
   # Rabl.host
   class Configuration
     attr_accessor :include_json_root
+    attr_accessor :include_child_root
     attr_accessor :include_msgpack_root
     attr_accessor :include_plist_root
     attr_accessor :include_xml_root
@@ -40,6 +41,7 @@ module Rabl
 
     def initialize
       @include_json_root     = true
+      @include_child_root    = true
       @include_msgpack_root  = true
       @include_plist_root    = true
       @include_xml_root      = false

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -45,7 +45,8 @@ module Rabl
     # to_json(:root => true)
     def to_json(options={})
       include_root = Rabl.configuration.include_json_root
-      options = options.reverse_merge(:root => include_root, :child_root => include_root)
+      include_child_root = Rabl.configuration.include_child_root
+      options = options.reverse_merge(:root => include_root, :child_root => include_child_root)
       result = collection_root_name ? { collection_root_name => to_hash(options) } : to_hash(options)
       format_json(result)
     end
@@ -54,7 +55,8 @@ module Rabl
     # to_msgpack(:root => true)
     def to_msgpack(options={})
       include_root = Rabl.configuration.include_msgpack_root
-      options = options.reverse_merge(:root => include_root, :child_root => include_root)
+      include_child_root = Rabl.configuration.include_child_root
+      options = options.reverse_merge(:root => include_root, :child_root => include_child_root)
       result = collection_root_name ? { collection_root_name => to_hash(options) } : to_hash(options)
       Rabl.configuration.msgpack_engine.pack result
     end
@@ -64,7 +66,8 @@ module Rabl
     # to_plist(:root => true)
     def to_plist(options={})
       include_root = Rabl.configuration.include_plist_root
-      options = options.reverse_merge(:root => include_root, :child_root => include_root)
+      include_child_root = Rabl.configuration.include_child_root
+      options = options.reverse_merge(:root => include_root, :child_root => include_child_root)
       result = defined?(@_collection_name) ? { @_collection_name => to_hash(options) } : to_hash(options)
       Rabl.configuration.plist_engine.dump(result)
     end
@@ -73,7 +76,8 @@ module Rabl
     # to_xml(:root => true)
     def to_xml(options={})
       include_root = Rabl.configuration.include_xml_root
-      options = options.reverse_merge(:root => include_root, :child_root => include_root)
+      include_child_root = Rabl.configuration.include_child_root
+      options = options.reverse_merge(:root => include_root, :child_root => include_child_root)
       xml_options = Rabl.configuration.default_xml_options.merge(:root => data_name(@_data))
       to_hash(options).to_xml(xml_options)
     end
@@ -82,7 +86,8 @@ module Rabl
     # to_bson(:root => true)
     def to_bson(options={})
       include_root = Rabl.configuration.include_bson_root
-      options = options.reverse_merge(:root => include_root, :child_root => include_root)
+      include_child_root = Rabl.configuration.include_child_root
+      options = options.reverse_merge(:root => include_root, :child_root => include_child_root)
       result = if collection_root_name
                  { collection_root_name => to_hash(options) }
                elsif is_collection?(@_data) && @_data.is_a?(Array)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -6,6 +6,7 @@ context 'Rabl::Configuration' do
     setup { Rabl.configuration }
 
     asserts(:include_json_root).equals true
+    asserts(:include_child_root).equals true
     asserts(:include_xml_root).equals false
     asserts(:enable_json_callbacks).equals false
     asserts(:json_engine).equals MultiJson.engine

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -419,4 +419,31 @@ context "Rabl::Engine" do
       Rabl.reset_configuration!
     end
   end
+  
+  context "without child root" do
+    setup do
+      Rabl.configure do |config|
+        config.include_child_root    = false
+        config.include_xml_root      = false
+        config.enable_json_callbacks = false
+      end
+    end
+    
+    context "#child" do
+      
+      asserts "that it can create a child node without child root" do
+        template = rabl %{
+          child @users
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new, User.new]
+        template.render(scope)
+      end.equals "{\"users\":[{},{}]}"
+
+    end
+
+    teardown do
+      Rabl.reset_configuration!
+    end
+  end
 end


### PR DESCRIPTION
This allows one to have the json root object, but no root objects in child nodes.
