### PR TITLE
Update multi_json gem version

### DIFF
--- a/rabl.gemspec
+++ b/rabl.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'multi_json',           '~> 1.0.3'
+  s.add_dependency 'multi_json',           '~> 1.1.0'
   s.add_dependency 'activesupport',        '>= 2.3.14'
 
   s.add_development_dependency 'riot',     '~> 0.12.3'


### PR DESCRIPTION
In order to make rabl 6.0 compatible with other gems I updated multi_json gem in rabl.gemspec to '~> 1.1.0'

All tests pass and everything seems to be good!
