### PR TITLE
allow builder's request_format to default to 'json' like engine

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -127,7 +127,8 @@ module Rabl
     # Returns a guess at the format in this scope
     # request_format => "xml"
     def request_format
-      @options[:format] if @options[:format] != "hash"
+      format = @options[:format]
+      format && format != "hash" ? format : 'json'
     end
 
     # Caches the results of the block based on object cache_key


### PR DESCRIPTION
Handles extended templates whose format is nil to find
the right template and works similar to how engine
is already working.

Unfortunately, I couldn't find a good test to setup
to mimic what I'm seeing though it does fix a problem
I have in my project.
