### PR TITLE
support Ruby 1.8 by not using parameters

### DIFF
--- a/lib/rabl/partials.rb
+++ b/lib/rabl/partials.rb
@@ -62,9 +62,9 @@ module Rabl
       source_format = request_format if defined?(request_format)
       if source_format && context_scope.respond_to?(:lookup_context) # Rails 3
         lookup_proc = lambda { |partial|
-          if context_scope.lookup_context.method(:find).parameters.count < 5
+          if ActionPack::VERSION::MAJOR == 3 && ActionPack::VERSION::MINOR < 2
             context_scope.lookup_context.find(file, [], partial)
-          else
+          else # Rails 3.2 and higher
             context_scope.lookup_context.find(file, [], partial, [], {:formats => [:json]})
           end }
         template = lookup_proc.call(false) rescue lookup_proc.call(true)


### PR DESCRIPTION
Can't use arity because it's -2 for both 3.1 and 3.2 since
the method signatures are compatible even though 
3.1 has 4 parameters and 3.2 has 5 parameters which
isn't what we were testing for.

This will have to be checked with Rails 4.0 but should work.

Solves Issue 214
