### PR TITLE
Fix for 'Sequel model instances respond_to :each'

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -50,12 +50,12 @@ module Rabl
     # is_object?([]) => false
     # is_object?({}) => false
     def is_object?(obj)
-      obj && !obj.class.included_modules.include?(Enumerable)
+      obj && !data_object(obj).class.included_modules.include?(Enumerable)
     end
 
     # Returns true if the obj is a collection of items
     def is_collection?(obj)
-      obj && obj.class.included_modules.include?(Enumerable)
+      obj && data_object(obj).class.included_modules.include?(Enumerable)
     end
 
     # Returns the scope wrapping this engine, used for retrieving data, invoking methods, etc


### PR DESCRIPTION
As mentioned in Issue #175.

When using Sequel to replace Active Record in rails.  rabl was considering all Sequel objects as collections, since each Sequel model instance has a method _each_.
