### PR TITLE
Uses __send__ over send

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -63,7 +63,7 @@ module Rabl
     # Indicates an attribute or method should be included in the json output
     # attribute :foo, :as => "bar"
     def attribute(name, options={})
-      @_result[options[:as] || name] = @_object.send(name) if @_object && @_object.respond_to?(name)
+      @_result[options[:as] || name] = @_object.__send__(name) if @_object && @_object.respond_to?(name)
     end
     alias_method :attributes, :attribute
 

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -94,7 +94,7 @@ module Rabl
     #
     # @param [Symbol] option Key for a given attribute
     def [](option)
-      send(option)
+      __send__(option)
     end
 
     # Returns merged default and inputted xml options

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -31,7 +31,7 @@ module Rabl
         instance_eval(@_source) if @_source.present?
       end
       instance_eval(&block) if block_given?
-      cache_results { self.send("to_" + @_options[:format].to_s) }
+      cache_results { self.__send__("to_" + @_options[:format].to_s) }
     end
 
     # Returns a hash representation of the data object
@@ -176,7 +176,7 @@ module Rabl
     # Includes a helper module with a RABL template
     # helper ExampleHelper
     def helper(*klazzes)
-      klazzes.each { |klazz| self.class.send(:include, klazz) }
+      klazzes.each { |klazz| self.class.__send__(:include, klazz) }
     end
     alias_method :helpers, :helper
 
@@ -213,7 +213,7 @@ module Rabl
     def format_json(json_output)
       json_engine = Rabl.configuration.json_engine
       json_method = json_engine.respond_to?(:dump) ? 'dump' : 'encode' # multi_json compatibility TODO
-      json_output = json_engine.send(json_method, json_output) unless json_output.is_a?(String)
+      json_output = json_engine.__send__(json_method, json_output) unless json_output.is_a?(String)
       use_callback = Rabl.configuration.enable_json_callbacks && request_params[:callback].present?
       use_callback ? "#{request_params[:callback]}(#{json_output})" : json_output
     end
@@ -225,7 +225,7 @@ module Rabl
 
     # Supports calling helpers defined for the template scope using method_missing hook
     def method_missing(name, *args, &block)
-      context_scope.respond_to?(name, true) ? context_scope.send(name, *args, &block) : super
+      context_scope.respond_to?(name, true) ? context_scope.__send__(name, *args, &block) : super
     end
 
     def copy_instance_variables_from(object, exclude = []) #:nodoc:

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -5,10 +5,10 @@ module Rabl
 
     # data_object(data) => <AR Object>
     # data_object(@user => :person) => @user
-    # data_object(:user => :person) => @_object.send(:user)
+    # data_object(:user => :person) => @_object.__send__(:user)
     def data_object(data)
       data = (data.is_a?(Hash) && data.keys.size == 1) ? data.keys.first : data
-      data.is_a?(Symbol) && @_object ? @_object.send(data) : data
+      data.is_a?(Symbol) && @_object ? @_object.__send__(data) : data
     end
 
     # data_name(data) => "user"
@@ -19,7 +19,7 @@ module Rabl
     def data_name(data)
       return nil unless data # nil or false
       return data.values.first if data.is_a?(Hash) # @user => :user
-      data = @_object.send(data) if data.is_a?(Symbol) && @_object # :address
+      data = @_object.__send__(data) if data.is_a?(Symbol) && @_object # :address
       if is_collection?(data) && data.respond_to?(:first) # data collection
         data_name(data.first).to_s.pluralize if data.first.present?
       elsif is_object?(data) # actual data object

--- a/test/partials_test.rb
+++ b/test/partials_test.rb
@@ -25,7 +25,7 @@ context "Rabl::Partials" do
 
     asserts(:first).equals {["content\n", (tmp_path + "test.json.rabl").to_s ]}
     asserts(:last).equals {["content_v1\n", (tmp_path + "test_v1.json.rabl").to_s ]}
-    teardown { Object.send(:remove_const, :Sinatra) }
+    teardown { Object.__send__(:remove_const, :Sinatra) }
   end
 
   context "fetch_source with rabl" do
@@ -41,7 +41,7 @@ context "Rabl::Partials" do
     asserts('detects file.rabl') { topic }.equals do
       ["content\n", (tmp_path + 'test.rabl').to_s]
     end
-    teardown { Object.send(:remove_const, :Sinatra) }
+    teardown { Object.__send__(:remove_const, :Sinatra) }
   end
 
   context "fetch_source with view_path" do
@@ -60,6 +60,6 @@ context "Rabl::Partials" do
     asserts('detects file.json.rabl first') { topic }.equals do
       ["content2\n", (tmp_path + 'test.json.rabl').to_s]
     end
-    teardown { Object.send(:remove_const, :Sinatra) }
+    teardown { Object.__send__(:remove_const, :Sinatra) }
   end
 end


### PR DESCRIPTION
rabl does not work well with decorators that use BasicObject as a
parent because BasicObject defines #__send__, not #send.

We ran into this with a gem called dumb_delegator that attempts to
delegate nearly everything to the underlying object, so you don't have
to do awkward things like explicitly delegate #class or #is_a? for
Rails. However, since Rabl uses #send, and not #__send__, messages are
not "overridden" correctly by the delegator.

A concrete example is in this gist:
https://gist.github.com/bb579e81d8353586d250
