### PR TITLE
[BUG FIX] Fixed a bug in extends which ommited the view path

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -107,7 +107,7 @@ module Rabl
     # Extends an existing rabl template with additional attributes in the block
     # extends("users/show") { attribute :full_name }
     def extends(file, options={}, &block)
-      options = @options.slice(:child_root).merge(options).merge(:object => @_object)
+      options = @options.slice(:child_root, :view_path).merge(options).merge(:object => @_object)
       result = self.partial(file, options, &block)
       @_result.merge!(result) if result
     end


### PR DESCRIPTION
Basically fixes an issue where view_path doesn't get set when using `extends` and rendering manually.
