### PR TITLE
Alternative solution to check if an object is a collection

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -55,12 +55,12 @@ module Rabl
     # is_object?([]) => false
     # is_object?({}) => false
     def is_object?(obj)
-      obj && !data_object(obj).respond_to?(:map)
+      obj && !data_object(obj).class.include?(Enumerable)
     end
 
     # Returns true if the obj is a collection of items
     def is_collection?(obj)
-      obj && data_object(obj).respond_to?(:map)
+      obj && data_object(obj).class.include?(Enumerable)
     end
 
     # Returns the scope wrapping this engine, used for retrieving data, invoking methods, etc


### PR DESCRIPTION
Hi nesquena,

One of my object fails to output any json as it has a custom method named map.

```
class Item
   def map
      self.maps.first
   end
end
```

I noticed that the is_collection and is_object methods use "data_object(obj).respond_to?(:map)" which was causing the object_to_hash method in the Partials module to work incorrectly.

So I replaced it with "data_object(obj).class.include?(Enumerable)". Seems to fix my issue. Is this the correct fix for the problem?

Thanks,
Dushyanth
