### PR TITLE
Add option to define his own cache_engine

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -11,6 +11,7 @@ require 'rabl/engine'
 require 'rabl/builder'
 require 'rabl/configuration'
 require 'rabl/renderer'
+require 'rabl/cache_engine'
 require 'rabl/railtie' if defined?(Rails) && Rails.version =~ /^3/
 
 # Rabl.register!

--- a/lib/rabl/cache_engine.rb
+++ b/lib/rabl/cache_engine.rb
@@ -1,0 +1,13 @@
+module Rabl
+  class CacheEngine
+
+    def fetch(key, cache_options, &block)
+      if defined?(Rails)
+        Rails.cache.fetch(key, cache_options, &block)
+      else
+        yield
+      end
+    end
+
+  end
+end

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -39,6 +39,7 @@ module Rabl
     attr_accessor :cache_all_output
     attr_accessor :escape_all_output
     attr_accessor :view_paths
+    attr_accessor :cache_engine
 
     DEFAULT_XML_OPTIONS = { :dasherize  => true, :skip_types => false }
 
@@ -61,6 +62,7 @@ module Rabl
       @cache_all_output      = false
       @escape_all_output     = false
       @view_paths            = []
+      @cache_engine          = Rabl::CacheEngine.new
     end
 
     # @param [Symbol, String, #encode] engine_name The name of a JSON engine,

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -87,7 +87,7 @@ module Rabl
     # fetch_from_cache('some_key') { ...rabl template result... }
     def fetch_result_from_cache(cache_key, cache_options=nil, &block)
       expanded_cache_key = ActiveSupport::Cache.expand_cache_key(cache_key, :rabl)
-      Rails.cache.fetch(expanded_cache_key, cache_options, &block) if defined?(Rails)
+      Rabl.configuration.cache_engine.fetch(expanded_cache_key, cache_options, &block)
     end
 
     # Returns true if the cache has been enabled for the application

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -13,6 +13,7 @@ context 'Rabl::Configuration' do
     asserts(:enable_json_callbacks).equals false
     asserts(:view_paths).equals []
     asserts(:json_engine).equals { json_engine }
+    asserts(:cache_engine).is_a?(Rabl::CacheEngine)
   end
 
   context 'custom JSON engine' do


### PR DESCRIPTION
Previously, you can cache your view render by rabl only by Rails.cache.
Now you can define you own cache_engine in Rabl::Configuration.

The Engine you can define is mandatory a class to define the #fetch
method.

By default a cache_engine exist in Rabl : Rabl::CacheEngine to see what
args take the fetch method. This method need return the result.

It's usefull to have the cache system outside of rails and you can use a specific cache_store like by example :

``` ruby
Rabl.configure do |config| 
  config.cache_engine = ActiveSupport::Cache.lookup_store :redis_store
end
```
