### PR TITLE
Add support for CSV format to RABL

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Rabl.configure do |config|
   # config.msgpack_engine = nil # Defaults to ::MessagePack
   # config.bson_engine = nil # Defaults to ::BSON
   # config.plist_engine = nil # Defaults to ::Plist::Emit
+  # config.csv_engine = nil # Defaults to ::CSV
   # config.include_json_root = true
   # config.include_msgpack_root = true
   # config.include_bson_root = true
@@ -114,6 +115,7 @@ Rabl.configure do |config|
   # config.include_child_root = true
   # config.enable_json_callbacks = false
   # config.xml_options = { :dasherize  => true, :skip_types => false }
+  # config.csv_options = { :col_sep => ';', :row_sep => '\n' }
   # config.view_paths = []
 end
 ```
@@ -515,6 +517,7 @@ Thanks to [Miso](http://gomiso.com) for allowing me to create this for our appli
 * [Alli Witheford](https://github.com/alzeih) - Added Plist format support
 * [Ryan Bigg](https://github.com/radar) - Improved template resolution code
 * [Ivan Vanderbyl](https://github.com/ivanvanderbyl) - Added general purpose renderer
+* [Guilherme Vieira | Flip Studio](https://github.com/gvieira | https://github.com/flipstudio) - Added CSV format support
 
 and many more contributors listed in the [CHANGELOG](https://github.com/nesquena/rabl/blob/master/CHANGELOG.md).
 

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -16,6 +16,12 @@ begin
 rescue LoadError
 end
 
+# We load the csv library if it is available.
+begin
+  require 'csv'
+rescue LoadError
+end
+
 # Load MultiJSON
 require 'multi_json'
 
@@ -34,7 +40,9 @@ module Rabl
     attr_writer   :msgpack_engine
     attr_writer   :bson_engine
     attr_writer   :plist_engine
+    attr_writer   :csv_engine
     attr_writer   :xml_options
+    attr_accessor   :csv_options
     attr_accessor :cache_sources
     attr_accessor :cache_all_output
     attr_accessor :escape_all_output
@@ -56,7 +64,9 @@ module Rabl
       @msgpack_engine        = nil
       @bson_engine           = nil
       @plist_engine          = nil
+      @csv_engine            = nil
       @xml_options           = {}
+      @csv_options           = {}
       @cache_sources         = false
       @cache_all_output      = false
       @escape_all_output     = false
@@ -94,6 +104,12 @@ module Rabl
     # @return the Plist encoder/engine to use.
     def plist_engine
       @plist_engine || ::Plist::Emit
+    end
+
+    ##
+    # @return the CSV encoder/engine to use.
+    def csv_engine
+      @csv_engine || ::CSV
     end
 
     # Allows config options to be read like a hash

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -3,7 +3,7 @@ module Rabl
     include Rabl::Partials
 
     # List of supported rendering formats
-    FORMATS = [:json, :xml, :plist, :bson, :msgpack]
+    FORMATS = [:json, :xml, :plist, :bson, :msgpack, :csv]
 
     # Constructs a new ejs engine based on given vars, handler and declarations
     # Rabl::Engine.new("...source...", { :format => "xml", :root => true, :view_path => "/path/to/views" })
@@ -105,6 +105,19 @@ module Rabl
                  to_hash(options)
                end
       Rabl.configuration.bson_engine.serialize(result).to_s
+    end
+
+    # Returns a csv representation of the data object
+    # to_csv()
+    def to_csv(options={})
+      options = options.reverse_merge(:root => false, :child_root => false)
+      result = to_hash(options)
+      if !result.is_a?(Array); result = [result] end
+      options = Rabl.configuration.csv_options
+      Rabl.configuration.csv_engine.generate options do |csv|
+        csv << result.first.map { |k, v| k } unless result.empty?
+        result.each { |hash| csv << hash.map { |k, v| v } }
+      end
     end
 
     # Sets the object to be used as the data source for this template

--- a/test/csv_engine_test.rb
+++ b/test/csv_engine_test.rb
@@ -1,0 +1,180 @@
+require File.expand_path('../teststrap', __FILE__)
+require File.expand_path('../../lib/rabl', __FILE__)
+require File.expand_path('../../lib/rabl/template', __FILE__)
+require File.expand_path('../models/user', __FILE__)
+
+context "Rabl::Engine" do
+  helper(:rabl) { |t| RablTemplate.new("code", :format => 'csv') { t } }
+
+  context "with csv defaults" do
+    setup do
+      Rabl.configure do |config|
+        
+      end
+    end
+
+    context "#attribute" do
+      asserts "that it adds attributes or method to be included in output" do
+        template = rabl %{
+          collection @users
+          attribute :name, :age
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'Arr', :age => 25), User.new(:name => 'Byy', :age => 12)]
+        template.render(scope)
+      end.equals "name,age\nArr,25\nByy,12\n"
+
+      asserts "that it can add attributes under a different key name through :as" do
+        template = rabl %{
+          collection @users
+          attribute :name, :as => :first_name
+          attribute :age
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'Arr', :age => 25), User.new(:name => 'Byy', :age => 12)]
+        template.render(scope)
+      end.equals "first_name,age\nArr,25\nByy,12\n"
+
+      asserts "that it can add attributes under a different key name through hash" do
+        template = rabl %{
+          collection @users
+          attribute :name => :first_name
+          attribute :age
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'Arr', :age => 25), User.new(:name => 'Byy', :age => 12)]
+        template.render(scope)
+      end.equals "first_name,age\nArr,25\nByy,12\n"
+    end
+
+    context "#child" do
+      asserts "that it can create a node" do
+        template = rabl %{
+          collection @users
+
+          attribute :city
+          node (:name) { |user| user.first + " " + user.name }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:first => "Asd", :name => 'Mir'), User.new(:first => "Sdw", :name => 'Sqq')]
+        template.render(scope)
+      end.equals "city,name\nirvine,Asd Mir\nirvine,Sdw Sqq\n"
+
+      asserts "that it can create a node with different key" do
+        template = rabl %{
+          collection @users
+
+          attribute :city
+          node (:full_name) { |user| user.first + " " + user.name }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:first => "Asd", :name => 'Mir'), User.new(:first => "Sdw", :name => 'Sqq')]
+        template.render(scope)
+      end.equals "city,full_name\nirvine,Asd Mir\nirvine,Sdw Sqq\n"
+
+      asserts "that it can create a conditional node" do
+        template = rabl %{
+          collection @users
+
+          attribute :city
+          node :full_name, :if => lambda { |u| false } do |user| 
+            user.first + " " + user.name
+          end
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:first => "Asd", :name => 'Mir'), User.new(:first => "Sdw", :name => 'Sqq')]
+        template.render(scope)
+      end.equals "city\nirvine\nirvine\n"
+    end
+
+    teardown do
+      Rabl.reset_configuration!
+    end
+  end
+
+  context "with csv config" do
+    setup do
+      Rabl.configure do |config|
+        config.csv_options = { :col_sep  => ';', :row_sep => '||' }
+      end
+    end
+
+    context "#attribute" do
+      asserts "that it adds attributes or method to be included in output" do
+        template = rabl %{
+          collection @users
+          attribute :name, :age
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'Arr', :age => 25), User.new(:name => 'Byy', :age => 12)]
+        template.render(scope)
+      end.equals "name;age||Arr;25||Byy;12||"
+
+      asserts "that it can add attributes under a different key name through :as" do
+        template = rabl %{
+          collection @users
+          attribute :name, :as => :first_name
+          attribute :age
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'Arr', :age => 25), User.new(:name => 'Byy', :age => 12)]
+        template.render(scope)
+      end.equals "first_name;age||Arr;25||Byy;12||"
+
+      asserts "that it can add attributes under a different key name through hash" do
+        template = rabl %{
+          collection @users
+          attribute :name => :first_name
+          attribute :age
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:name => 'Arr', :age => 25), User.new(:name => 'Byy', :age => 12)]
+        template.render(scope)
+      end.equals "first_name;age||Arr;25||Byy;12||"
+    end
+
+    context "#child" do
+      asserts "that it can create a node" do
+        template = rabl %{
+          collection @users
+
+          attribute :city
+          node (:name) { |user| user.first + " " + user.name }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:first => "Asd", :name => 'Mir'), User.new(:first => "Sdw", :name => 'Sqq')]
+        template.render(scope)
+      end.equals "city;name||irvine;Asd Mir||irvine;Sdw Sqq||"
+
+      asserts "that it can create a node with different key" do
+        template = rabl %{
+          collection @users
+
+          attribute :city
+          node (:full_name) { |user| user.first + " " + user.name }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:first => "Asd", :name => 'Mir'), User.new(:first => "Sdw", :name => 'Sqq')]
+        template.render(scope)
+      end.equals "city;full_name||irvine;Asd Mir||irvine;Sdw Sqq||"
+
+      asserts "that it can create a conditional node" do
+        template = rabl %{
+          collection @users
+
+          attribute :city
+          node :full_name, :if => lambda { |u| false } do |user| 
+            user.first + " " + user.name
+          end
+        }
+        scope = Object.new
+        scope.instance_variable_set :@users, [User.new(:first => "Asd", :name => 'Mir'), User.new(:first => "Sdw", :name => 'Sqq')]
+        template.render(scope)
+      end.equals "city||irvine||irvine||"
+    end
+
+    teardown do
+      Rabl.reset_configuration!
+    end
+  end
+end


### PR DESCRIPTION
I know CSV is not a proper tree structure as JSON, XML and PList, anyway I needed to export data to CSV in a project that was already using RABL and I thought it would be great to use the same engine.

It uses the ruby's built-in CSV engine but it can also use FasterCSV and any other engine that provides a generate method.

I have also added a csv_options that accepts a hash and passes it to generate method, so people can set their own column and row separators, as much as other many options (see http://www.ruby-doc.org/stdlib-1.9.3/libdoc/csv/rdoc/CSV.html#method-c-new).

(Based on https://github.com/nesquena/rabl/pull/153)
