### PR TITLE
Use params of locals pass on Rabl::Engine to be method

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -239,7 +239,12 @@ module Rabl
 
     # Supports calling helpers defined for the template scope using method_missing hook
     def method_missing(name, *args, &block)
-      context_scope.respond_to?(name, true) ? context_scope.__send__(name, *args, &block) : super
+      if context_scope.respond_to?(name, true)
+        return context_scope.__send__(name, *args, &block)
+      elsif @_locals.key?(name)
+        return @_locals[name]
+      end
+      super
     end
 
     def copy_instance_variables_from(object, exclude = []) #:nodoc:


### PR DESCRIPTION
When you pass locals params on your Rabl.render you can now use it like
instance method in your rabl view. By example if you have a view like :

``` ruby
object blog
attributes :content, :title
```

you can define your blog elements directly in you Rabl.render like :

``` ruby
Rabl.render(nil, 'blog/show', {
  :view_paths => 'app/view',
  :locals => { :blog => Blog.new }
})
```
