### PR TITLE
fix partial test modifying the global view path

### DIFF
--- a/test/partials_test.rb
+++ b/test/partials_test.rb
@@ -84,6 +84,9 @@ context "Rabl::Partials" do
     asserts('detects file.json.rabl first') { topic }.equals do
       ["content2\n", (tmp_path + 'test.json.rabl').to_s]
     end
-    teardown { Object.send(:remove_const, :Sinatra) }
+    teardown do
+      Object.send(:remove_const, :Sinatra)
+      Rabl.configuration.view_paths = []
+    end
   end
 end


### PR DESCRIPTION
I'm seeing the renderer_test fail with the following errror

```
Rabl::Renderer #render asserts uses globally configured view paths => undefined local variable or method `content2' for #<Rabl::Engine:0x00000001e389f0> occured
 at /home/wyaeld/rails_projects/rabl/test/renderer_test.rb:102:in `block (3 levels) in <top (required)>'
at /home/wyaeld/rails_projects/rabl/lib/rabl/renderer.rb:48:in `render'
at /home/wyaeld/rails_projects/rabl/lib/rabl/engine.rb:32:in `render'
at /home/wyaeld/rails_projects/rabl/lib/rabl/engine.rb:32:in `instance_eval'
at (eval):1:in `render'
at /home/wyaeld/rails_projects/rabl/lib/rabl/engine.rb:32:in `instance_eval'

194 passes, 0 failures, 1 errors in 0.156562 seconds
```

Which I traced to the Rabl.configuration.view_paths acting as global state that isn't always being cleaned up.  One of the partial tests actually assigned a single path to it, so it becomes no longer an array, and then renderer blows up.

```
partial_test.rb:72
config.view_paths = tmp_path
```

Fixed by adding some teardown in the test at fault.
