### PR TITLE
Pass data object to rendered block.

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -31,7 +31,7 @@ module Rabl
       else # without source location
         instance_eval(@_source) if @_source.present?
       end
-      instance_eval(&block) if block_given?
+      instance_exec(data_object(@_data), &block) if block_given?
       cache_results { self.send("to_" + @_options[:format].to_s) }
     end
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -263,6 +263,18 @@ context "Rabl::Engine" do
         template.render(scope).split('').sort
 
       end.equals "{\"user\":{\"name\":\"leo\",\"person\":{\"city\":\"LA\"}}}".split('').sort
+
+      asserts "that it passes the data object to the block" do
+        template = rabl %{
+          object @user
+          child(@user => :person) do |user|
+            attribute :name if user.name == 'leo'
+          end
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo')
+        template.render(scope)
+      end.equals "{\"user\":{\"person\":{\"name\":\"leo\"}}}"
     end
 
     context "#glue" do
@@ -475,7 +487,7 @@ context "Rabl::Engine" do
       Rabl.reset_configuration!
     end
   end
-  
+
   context "without child root" do
     setup do
       Rabl.configure do |config|
@@ -484,9 +496,9 @@ context "Rabl::Engine" do
         config.enable_json_callbacks = false
       end
     end
-    
+
     context "#child" do
-      
+
       asserts "that it can create a child node without child root" do
         template = rabl %{
           child @users


### PR DESCRIPTION
In a child block, I often need to conditionally render some portion based on properties of the data object.  Ideally, the data object would be passed in to the block like so:

``` ruby
child :obj do |obj|
  attribute :x if obj.condition?
end
```

However, no arguments are passed to the block and I generally use one of several ugly workarounds involving `node` and `glue`.  This patch allows the above by passing the data object to the child block.
