### PR TITLE
Set instance variables in engine instead of renderer

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -23,6 +23,7 @@ module Rabl
       reset_options!
       @_locals, @_scope = locals, scope
       self.copy_instance_variables_from(@_scope, [:@assigns, :@helpers])
+      locals.each { |k,v| instance_variable_set(:"@#{k}", v) }
       @_options[:scope] = @_scope
       @_options[:format] ||= self.request_format
       @_data = locals[:object] || self.default_object

--- a/lib/rabl/renderer.rb
+++ b/lib/rabl/renderer.rb
@@ -32,12 +32,6 @@ module Rabl
       @options = options
       @object = object
 
-      if @options[:locals]
-        @options[:locals].delete(:object) if @object
-        @options[:locals].each do |k,v|
-          instance_variable_set(:"@#{k}", v)
-        end
-      end
       engine.source = self.process_source(source)
     end
 


### PR DESCRIPTION
Currently, instance variables are set on the `renderer` object based on what's provided in `options[:locals]`.  When we render with the default context (self), these instance variables are copied to the `engine` object via `copy_instance_variables_from(@_scope, [:@assigns, :@helpers])`.

This logic breaks when we render with a separate scope.  The instance variables are still copied onto the `renderer` object, but when we `copy_instance_variables_from(@_scope, [:@assigns, :@helpers])`, `@_scope` is another context/scope, and we don't have access to the instance variables in the template as we'd expect.

This commit sets the instance variables onto `engine` directly, without relying on `@_scope`.
