### PR TITLE
Changed the way Rabl handled default JSON engine for Rails. Issue #326

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Rabl.configure do |config|
   # config.cache_sources = Rails.env != 'development' # Defaults to false
   # config.cache_engine = Rabl::CacheEngine.new # Defaults to Rails cache
   # config.escape_all_output = false
-  # config.json_engine = nil # Any multi\_json engines
+  # config.json_engine = nil # Any multi_json engines or a Class with #encode method
   # config.msgpack_engine = nil # Defaults to ::MessagePack
   # config.bson_engine = nil # Defaults to ::BSON
   # config.plist_engine = nil # Defaults to ::Plist::Emit
@@ -151,7 +151,7 @@ If `view_paths` is set to a path, this view path will be checked for every rabl 
 Add to this path especially when including Rabl in an engine and using view paths within a another Rails app.
 
 Note that the `json_engine` option uses [multi_json](http://intridea.com/2010/6/14/multi-json-the-swappable-json-handler) engine
-defaults so that in most cases you **don't need to configure this** directly. If you wish to use yajl as
+defaults so that in most cases you **don't need to configure this** directly. For example, if you wish to use yajl as
 the primary JSON encoding engine simply add that to your Gemfile:
 
 ```ruby
@@ -160,6 +160,10 @@ gem 'yajl-ruby', :require => "yajl"
 ```
 
 and RABL will automatically start using that engine for encoding your JSON responses!
+To use RABL with JSON engine not supported by `multi_json`, ensure that JSON engine supports `encode` method and set `json_engine` option to the engine's Class name:
+```ruby
+config.json_engine = ActiveSupport::JSON
+```
 
 ### Format Configuration ###
 

--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -12,6 +12,7 @@ require 'rabl/builder'
 require 'rabl/configuration'
 require 'rabl/renderer'
 require 'rabl/cache_engine'
+require 'rabl/json_engine'
 require 'rabl/railtie' if defined?(Rails) && Rails.version =~ /^3/
 
 # Rabl.register!

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -16,9 +16,6 @@ begin
 rescue LoadError
 end
 
-# Load MultiJSON
-require 'multi_json'
-
 module Rabl
   # Rabl.host
   class Configuration
@@ -65,19 +62,16 @@ module Rabl
       @cache_engine          = Rabl::CacheEngine.new
     end
 
-    # @param [Symbol, String, #encode] engine_name The name of a JSON engine,
+    # @param [Symbol, Class] engine_name The name of a JSON engine,
     #   or class that responds to `encode`, to use to encode Rabl templates
     #   into JSON. For more details, see the MultiJson gem.
     def json_engine=(engine_name_or_class)
-      @engine_name = engine_name_or_class
-      # multi_json compatibility TODO
-      MultiJson.respond_to?(:use) ? MultiJson.use(@engine_name) :
-        MultiJson.engine = @engine_name
+      JsonEngine.instance.set(engine_name_or_class)
     end
 
     # @return The JSON engine used to encode Rabl templates into JSON
     def json_engine
-      get_json_engine
+      JsonEngine.instance.current_engine
     end
 
     ##
@@ -108,17 +102,6 @@ module Rabl
     # Returns merged default and inputted xml options
     def default_xml_options
       @_default_xml_options ||= @xml_options.reverse_merge(DEFAULT_XML_OPTIONS)
-    end
-
-    private
-
-    def get_json_engine
-      if !defined?(@engine_name) && defined?(Rails)
-        ActiveSupport::JSON
-      else # use multi_json
-        # multi_json compatibility TODO
-        MultiJson.respond_to?(:adapter) ? MultiJson.adapter : MultiJson.engine
-      end
     end
   end
 end

--- a/lib/rabl/json_engine.rb
+++ b/lib/rabl/json_engine.rb
@@ -1,0 +1,22 @@
+require 'multi_json'
+require 'singleton'
+
+module Rabl
+  class JsonEngine
+    include Singleton
+
+    attr_reader :current_engine
+
+    def initialize
+      @current_engine = MultiJson.respond_to?(:adapter) ? MultiJson.adapter : MultiJson.engine
+    end
+
+    def set(engine_name_or_class)
+      @current_engine = begin
+        MultiJson.respond_to?(:use) ? MultiJson.use(engine_name_or_class) : MultiJson.engine = engine_name_or_class
+      rescue
+        engine_name_or_class
+      end
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -16,7 +16,7 @@ context 'Rabl::Configuration' do
     asserts(:cache_engine).is_a?(Rabl::CacheEngine)
   end
 
-  context 'custom JSON engine' do
+  context 'custom JSON engine configured as Symbol' do
     setup do
       Rabl.configure do |c|
         c.json_engine = :yajl
@@ -24,5 +24,15 @@ context 'Rabl::Configuration' do
     end
 
     asserts('uses a custom JSON engine') { topic.json_engine.to_s =~ /MultiJson.*::Yajl/ }
+  end
+
+  context 'custom JSON engine configured as Class' do
+    setup do
+      Rabl.configure do |c|
+        c.json_engine = ActiveSupport::JSON
+      end
+    end
+
+    asserts('uses a custom JSON engine') { topic.json_engine.to_s == 'ActiveSupport::JSON' }
   end
 end


### PR DESCRIPTION
Changed the way Rabl handled default JSON engine in Rails environment to comply with documentation. Added ability to specify JSON engines not supported by MultiJson, these engines can be specified by Class name only.
