### PR TITLE
Bad keys used for caching

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -14,8 +14,6 @@ module Rabl
     # data_object_attribute(data) => @_object.send(data)
     def data_object_attribute(data)
       escape_output @_object.__send__(data)
-      hash = hash.as_json if hash and hash.respond_to?(:as_json) and !hash.is_a?(String) and !hash.is_a?(Fixnum) and !hash.is_a?(ActiveSupport::TimeWithZone) and !hash.is_a?(Array)
-      hash
     end
 
     # data_name(data) => "user"


### PR DESCRIPTION
The issue I was having was that templates will render fine when fed an AR relation, since they respond fine to each. But when you try to use one as a key in caching, it doesn't end well

```
"rabl/1/#<ActiveRecord::Relation:0x007f85014ad930>//json"
```

That is just one example of the keys I was ending up with in my cache. The solution is to unpack the relations in to regular arrays. 
I didn't really see a good place for this logic, so I just placed the code as close as I could to AS.

Also, I see it as more of an error with the "ActiveSupport::Cache.expand_cache_key" function, but I'd rather fix it in Rabl than in AS since I can more easily fix unexpected side-effects should any appear. And, perhaps the function is actually working the way AS intends, but I don't have the time to look in to that.

p.s.
Sorry about the 2nd and 3rd commits. I didn't realize that making subsequent commits would automatically add them to the pull request.
