### PR TITLE
Fixing problem with "object false" including root

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -113,6 +113,7 @@ module Rabl
     # object @user => :person
     # object @users
     def object(data)
+      @_object_root_name = false if data == false && @_locals[:object]
       @_data = data unless @_locals[:object]
     end
 

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -229,6 +229,18 @@ context "Rabl::Renderer" do
       Rabl.render([], 'test', :view_path => tmp_path, :root => false, :scope => scope)
     end.equals "[]"
 
+    asserts 'should not render object root if set to false' do
+      File.open(tmp_path + "no_root.json.rabl", "w") do |f|
+        f.puts %q{
+          object false
+          node(:foo) { 'bar' }
+        }
+      end 
+      scope = Object.new
+      scope.instance_variable_set :@resource, nil
+      Rabl.render(scope, 'no_root', :view_path => tmp_path)
+    end.equals '{"foo":"bar"}'
+
     asserts 'handles view path for when it specified and config is empty' do
       Rabl.configuration.view_paths = []
 


### PR DESCRIPTION
Fixes when in template "object false" is used and should exclude the root. I wrote a test first to replicate the problem. Then I fixed it. I ran the rest of the tests and there were two tests that were not working related to UTC vs Z timestamps. I don't think the failing specs are related. As far as I can tell this fixes the issue #348 I was having.
