### PR TITLE
rails 2.3.2 compatibility, fixes "undefined method `element`"

### DIFF
--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -28,7 +28,147 @@ context "Rabl::Helpers" do
     asserts "returns name of an object" do
       @helper_class.data_name(@user)
     end.equals('user')
+
+    context 'when is_object?' do
+      setup do
+        stub(@helper_class).is_object? { true }
+        mock(@helper_class).name_for_data_object(@user) { 'blankenfresh' }
+      end
+
+      asserts "calls #name_for_data_object" do
+        @helper_class.data_name(@user)
+      end.equals('blankenfresh')
+    end
   end # data_name method
+
+  context 'for name_for_data_object method' do
+    context 'when object_root_name not nil' do
+      setup do
+        stub(@helper_class).object_root_name { 'a_name' }
+      end
+
+      asserts 'returns object_root_name' do
+        @helper_class.name_for_data_object(@user)
+      end.equals('a_name')
+    end
+
+    context 'when object_root_name is nil' do
+      setup do
+        stub(@helper_class).object_root_name { nil }
+      end
+
+      context 'when has a collection_root_name' do
+        setup do
+          stub(@helper_class).collection_root_name { 'peoples' }
+        end
+
+        asserts 'returns the singularized collection name' do
+          @helper_class.name_for_data_object(@user)
+        end.equals('people')
+      end
+
+      context 'when does not have collection_root_name' do
+        setup do
+          stub(@helper_class).collection_root_name { nil }
+        end
+
+        context 'when calling element_name_for_data_object_class' do
+          setup do
+            stub(@helper_class).element_name_for_data_object_class(@user.class) {
+              'element_name'
+            }
+          end
+          asserts 'gets element_name_for_data_object_class' do
+            @helper_class.name_for_data_object(@user)
+          end.equals('element_name')
+        end # when calling element_name_for_data_object_class
+      end # when does not have collection_root_name
+    end # when object_root_name is nil
+  end #name_for_data_object method
+
+  context 'for element_name_for_data_object_class method' do
+    context 'when class responds_to :model_name' do
+      setup do
+        @model_class  = Object.new
+
+        # rr can't stub respond_to?
+        def @model_class.respond_to?(thing)
+          if thing == :model_name
+            true
+          else
+            super
+          end
+        end
+
+        stub(@helper_class).element_name_for_model_class(@model_class) {
+          'name_from #element_name_for_model_class'
+        }
+      end
+
+      asserts 'uses result from #element_name_for_model_class' do
+        @helper_class.element_name_for_data_object_class(@model_class)
+      end.equals('name_from #element_name_for_model_class')
+
+    end # when class responds_to :model_name
+
+    context 'when class does not responds_to :model_name' do
+      setup do
+        @model_class  = Object.new
+
+        # rr can't stub respond_to?
+        def @model_class.respond_to?(thing)
+          if thing == :model_name
+            false
+          else
+            super
+          end
+        end
+
+        stub(@model_class).to_s { 'Dilworth' }
+      end #setup
+
+      asserts 'it uses calls chain to_s.downcase on class' do
+        @helper_class.element_name_for_data_object_class(@model_class)
+      end.equals('dilworth')
+    end
+  end #element_name_for_data_object_class
+
+  context 'for element_name_for_model_class method' do
+    context 'when respond_to :element' do
+      setup do
+        # using generic object
+        # and descriptive string
+        # here since
+        # stubbing :respond_to? on a rr
+        # mock always returns false
+        @mock_class     = Object.new
+        mock_model_name = 'ActiveModel::Naming instance'
+
+        stub(mock_model_name).respond_to?(:element)     { true }
+        stub(mock_model_name).element      { 'another_user' }
+        stub(@mock_class).model_name  { mock_model_name }
+      end
+
+      asserts "reads element accessor" do
+        @helper_class.element_name_for_model_class(@mock_class)
+      end.equals('another_user')
+
+    end # respond_to :element
+
+    context 'when does not respond_to :element' do
+      setup do
+        @mock_class     = Object.new
+        mock_model_name = 'ActiveSupport::ModelName rails 232 fix'
+
+        stub(mock_model_name).respond_to?(:element)     { false }
+        stub(@mock_class).model_name  { mock_model_name }
+      end
+
+      asserts "uses ActiveSupport::Inflector" do
+        @helper_class.element_name_for_model_class(@mock_class)
+      end.equals('model_name rails 232 fix')
+    end
+  end #element_name_for_model_class
 
   context "for is_object method" do
     asserts "returns nil if no data" do


### PR DESCRIPTION
adds rails 2.3.2 compatibility, fixes error seen here:  https://gist.github.com/4150783

in rails 2.3.2 the ActiveSupport::ModelName object doesn't yet set the
'element' accessor used in Rabl::Helpers#data_name method

if the object returned by the model_name method on the data object's
class doesn't respond_to :element, instead return what the element
method call would initialize that attribute as in 2.3.8
