### PR TITLE
child fails on embedded documents (Mongoid)

### DIFF
--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -17,6 +17,10 @@ context "Rabl::Helpers" do
       @helper_class.data_name(nil)
     end.equals(nil)
 
+    asserts "returns symbol if symbol with empty children" do
+      @helper_class.data_name(:user)
+    end.equals(:user)
+
     asserts "returns alias if hash with symbol is passed" do
       @helper_class.data_name(@user => :user)
     end.equals(:user)


### PR DESCRIPTION
This fails:

Given the following setup:

``` ruby
class Parent
  include Mongoid::Document
  field :name

  embeds_many :children
end

class Child
  include Mongoid::Document
  field :name

  embedded_in :parent
end
```

The following code **fails** (returning null for the child `:children`):

``` ruby
object @parent

child :children do
  attributes :name
end
```

The following code **succeeds**, but is ugly:

``` ruby
object @parent

child @parent.children => :children do
  attributes :name
end
```

``` text
Ruby:    1.9.3, but verified issue on 1.9.2 and 2.0.0
OS:      Mac OSX 10.8.2
Rabl:    0.7.8, but also verified issue on master
Rails:   3.2.9
```
