### PR TITLE
#attribute method accept multiple symbols along with the hash of attributes

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -152,16 +152,19 @@ module Rabl
 
     # Indicates an attribute or method should be included in the json output
     # attribute :foo, :as => "bar"
+    # attribute :foo, :bar => :baz
     # attribute :foo => :bar, :bar => :baz
     # attribute :foo => :bar, :bar => :baz, :if => lambda { |r| r.foo }
     def attribute(*args)
-      if args.first.is_a?(Hash) # :foo => :bar, :bar => :baz
-        attr_aliases, conds = args.first.except(:if, :unless), args.first.slice(:if, :unless)
-        attr_aliases.each_pair { |k,v| self.attribute(k, conds.merge(:as => v)) }
-      else # array of attributes i.e :foo, :bar, :baz
-        attr_options = args.extract_options!
-        args.each { |name| @_options[:attributes][name] = attr_options }
+      options = args.extract_options!
+      attr_aliases = options.slice!(:if, :unless, :as)
+      if options.has_key?(:as)
+        raise ArgumentError, "parameter :as can't be passed along with a hash" if attr_aliases.present?
+        raise ArgumentError, "parameter :as can't be passed along with multiple arguments" if args.size > 1
       end
+
+      args.each { |name| @_options[:attributes][name] = options }
+      attr_aliases.each_pair{ |k, v| self.attribute(k, options.merge(:as => v)) }
     end
     alias_method :attributes, :attribute
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -201,6 +201,56 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@user, User.new(:name => 'irvine')
         JSON.parse(template.render(scope))
       end.equals JSON.parse("{\"user\":{\"city\":\"irvine\"}}")
+
+      asserts "that it can add an attribute through symbol or hash" do
+        template = rabl %{
+          object @user
+          attribute :age, :name => :city
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine', :age => "18")
+        JSON.parse(template.render(scope))
+      end.equals JSON.parse("{\"user\":{\"city\":\"irvine\", \"age\":\"18\"}}")
+
+      asserts "that a conditional (true) can be passed" do
+        template = rabl %{
+          object @user
+          attribute :age, :name => :city, :if => lambda { |u| true }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine', :age => "18")
+        JSON.parse(template.render(scope))
+      end.equals JSON.parse("{\"user\":{\"city\":\"irvine\", \"age\":\"18\"}}")
+
+      asserts "that a conditional (false) can be passed" do
+        template = rabl %{
+          object @user
+          attribute :age, :name => :city, :if => lambda { |u| false }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'irvine', :age => "18")
+        JSON.parse(template.render(scope))
+      end.equals JSON.parse("{\"user\":{}}")
+
+      asserts "that it raise an ArgumentError when :as is passed along with a hash" do
+        template = rabl %{
+          object @user
+          attribute :age, :name => :city, :as => "foo"
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new
+        JSON.parse(template.render(scope))
+      end.raises(ArgumentError)
+
+      asserts "that it raise an ArgumentError when :as is passed along with multiple attributes" do
+        template = rabl %{
+          object @user
+          attribute :age, :name, :as => "foo"
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new
+        JSON.parse(template.render(scope))
+      end.raises(ArgumentError)
     end
 
     context "#code" do


### PR DESCRIPTION
With this pull request you can pass symbols and hash to the `attribute` method

``` ruby
attribute :foo, :bar => :baz
```
