### PR TITLE
Add magic comment for Ruby2.0.0

### DIFF
--- a/test/msgpack_engine_test.rb
+++ b/test/msgpack_engine_test.rb
@@ -1,3 +1,4 @@
+# coding: US-ASCII
 require File.expand_path('../teststrap', __FILE__)
 require 'rabl/template'
 

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -1,3 +1,4 @@
+# coding: US-ASCII
 require 'tmpdir'
 require 'pathname'
 require 'json'


### PR DESCRIPTION
invalid byte sequence in UTF-8 (ArgumentError)
Ruby2.0.0 default encoding is UTF-8 instead of US_ASCII
