### PR TITLE
use has_attribute? as per https://github.com/rails/rails/issues/4208

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -130,7 +130,15 @@ module Rabl
     # Checks if an attribute is present. If not, check if the configuration specifies that this is an error
     # attribute_present?(created_at) => true
     def attribute_present?(name)
-      if @_object.respond_to?(name)
+      if defined?(Rails)
+        begin 
+          @_object.send(name) and return true
+        rescue ActiveModel::MissingAttributeError
+          return false
+        end
+      end       
+      
+      if @_object.respond_to?(name) 
         return true
       elsif Rabl.configuration.raise_on_missing_attribute
         raise "Failed to render missing attribute #{name}"


### PR DESCRIPTION
The `raise_on_missing_attribute` seems not to be working. I only tested on rails 3.2.11

It seems the current behavior is `respond_to?` will always return true so `has_attribute?` is recommended. 

I put this together very quickly. Let me know if further investigation or code is required.
