### PR TITLE
fixes #386 - child() supports :object_root => false 

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -100,7 +100,7 @@ module Rabl
     def child(data, options={}, &block)
       return false unless data.present? && resolve_condition(options)
       name, object = data_name(data), data_object(data)
-      include_root = is_collection?(object) && @options[:child_root] # child @users
+      include_root = is_collection?(object) && options.fetch(:object_root, @options[:child_root]) # child @users
       engine_options = @options.slice(:child_root).merge(:root => include_root)
       object = { object => name } if data.respond_to?(:each_pair) && object # child :users => :people
       @_result[name] = self.object_to_hash(object, engine_options, &block)

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -280,6 +280,31 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@user, User.new(:name => 'leo')
         template.render(scope)
       end.equals "{\"user\":{\"person\":{\"name\":\"leo\"}}}"
+
+      asserts "it sets root node for child collection" do
+        template = rabl %{
+          object @user
+          attribute :name
+          child(@users) { attribute :city }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA')
+        scope.instance_variable_set :@users, [User.new(:name => 'one', :city => 'UNO'), User.new(:name => 'two', :city => 'DOS')]
+        template.render(scope)
+      end.equals "{\"user\":{\"name\":\"leo\",\"users\":[{\"user\":{\"city\":\"UNO\"}},{\"user\":{\"city\":\"DOS\"}}]}}"
+
+      asserts "it allows suppression of root node for child collection" do
+        template = rabl %{
+          object @user
+          attribute :name
+          child(@users, :object_root => false) { attribute :city }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA')
+        scope.instance_variable_set :@users, [User.new(:name => 'one', :city => 'UNO'), User.new(:name => 'two', :city => 'DOS')]
+        template.render(scope)
+      end.equals "{\"user\":{\"name\":\"leo\",\"users\":[{\"city\":\"UNO\"},{\"city\":\"DOS\"}]}}"
+
     end
 
     context "#glue" do


### PR DESCRIPTION
Added :object_root support to child() to suppress root node for child collection. Added tests for both root and non-root cases.
