### PR TITLE
options hash for glue function added

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -47,7 +47,7 @@ module Rabl
       end if @options.has_key?(:child)
       # Glues
       @options[:glue].each do |settings|
-        glue(settings[:data], &settings[:block])
+        glue(settings[:data], settings[:options], &settings[:block])
       end if @options.has_key?(:glue)
 
       # Wrap result in root
@@ -108,8 +108,8 @@ module Rabl
 
     # Glues data from a child node to the json_output
     # glue(@user) { attribute :full_name => :user_full_name }
-    def glue(data, &block)
-      return false unless data.present?
+    def glue(data, options={}, &block)
+      return false unless data.present? && resolve_condition(options)
       object = data_object(data)
       glued_attributes = self.object_to_hash(object, :root => false, &block)
       @_result.merge!(glued_attributes) if glued_attributes

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -183,8 +183,8 @@ module Rabl
 
     # Glues data from a child node to the json_output
     # glue(@user) { attribute :full_name => :user_full_name }
-    def glue(data, &block)
-      @_options[:glue].push({ :data => data, :block => block })
+    def glue(data, options={}, &block)
+      @_options[:glue].push({ :data => data, :options => options, :block => block })
     end
 
     # Extends an existing rabl template with additional attributes in the block

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -137,18 +137,18 @@ context "Rabl::Builder" do
     end.equals({})
 
     asserts "that it generates the glue attributes" do
-      b = builder :glue => [{ :data => @user, :block => lambda { |u| attribute :name }}]
+      b = builder :glue => [{ :data => @user, :options => {}, :block => lambda { |u| attribute :name }}]
       mock(b).object_to_hash(@user, { :root => false }).returns({:user => 'xyz'}).subject
       b.build(@user)
     end.equivalent_to({ :user => 'xyz' })
 
     asserts "that it appends the glue attributes to result" do
-      b = builder :glue => [{ :data => @user, :block => lambda { |u| attribute :name => :user_name }}]
+      b = builder :glue => [{ :data => @user, :options => {}, :block => lambda { |u| attribute :name => :user_name }}]
       b.build(@user)
     end.equivalent_to({ :user_name => 'rabl' })
 
     asserts "that it does not generate new attributes if no glue attributes are present" do
-      b = builder :glue => [{ :data => @user, :block => lambda { |u| attribute :name }}]
+      b = builder :glue => [{ :data => @user, :options => {}, :block => lambda { |u| attribute :name }}]
       mock(b).object_to_hash(@user,{ :root => false }).returns({}).subject
       b.build(@user)
     end.equals({})

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -624,6 +624,17 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA', :age => 12)
         JSON.parse(template.render(scope))
       end.equals JSON.parse("{\"name\":\"leo\",\"city\":\"LA\",\"age\":12}")
+
+      asserts "that it can be passed conditionals" do
+        template = rabl %{
+          object @user
+          attribute :name
+          glue(@user, {:if => lambda { |i| false }}) { attribute :age  }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :city => 'LA', :age => 12)
+        JSON.parse(template.render(scope))
+      end.equals JSON.parse("{\"name\":\"leo\"}")
     end
 
     teardown do


### PR DESCRIPTION
Hi, while using rabl I wondered why glue does not accept an if-lambda condition the same way as child and node do. I've seen that it was not implemented, yet, so here's my implementation. I also added 1 test case, which passes of course.

Hope you like it.

Thorsten

P.S.: This is my very first pull request - please don't ignore it if something's wrong. Instead, tell me about it!
