### PR TITLE
Template lookup when Padrino is defined fails

### DIFF
--- a/lib/rabl/partials.rb
+++ b/lib/rabl/partials.rb
@@ -32,7 +32,7 @@ module Rabl
     def fetch_source(file, options={})
       view_paths = Array(options[:view_path]) + Array(Rabl.configuration.view_paths)
       Rabl.source_cache(file, view_paths) do
-        file_path = if defined?(Padrino) && context_scope.respond_to?(:settings)
+        file_path = if defined?(Padrino) && context_scope.respond_to?(:settings) && context_scope.respond_to?(:resolve_template)
           fetch_padrino_source(file, options)
         elsif defined?(Rails) && context_scope.respond_to?(:view_paths)
           _view_paths = view_paths + Array(context_scope.view_paths.to_a)

--- a/test/partials_test.rb
+++ b/test/partials_test.rb
@@ -89,6 +89,32 @@ context "Rabl::Partials" do
     end
   end
 
+  context "fetch source with custom scope" do
+    context "when Padrino is defined" do
+      helper(:tmp_path) { @tmp_path ||= Pathname.new(Dir.mktmpdir) }
+
+      setup do
+        ::Padrino = stub(Class.new)
+        Rabl.configuration.cache_sources = false
+        @it = TestPartial.new
+
+        def @it.context_scope; @context_scope ||= Object.new; end
+        context_scope = @it.context_scope
+        def context_scope.settings; end
+
+        File.open(tmp_path + "test.json.rabl", "w") { |f| f.puts "content" }
+      end
+
+      asserts('Padrino constant dont break manual lookup') do
+        @it.fetch_source('test', :view_path => tmp_path.to_s)
+      end.equals do
+        ["content\n", (tmp_path + "test.json.rabl").to_s ]
+      end
+
+      teardown { Object.send(:remove_const, :Padrino) }
+    end
+  end
+
   context "fetch source with Rails" do
     context "and :view_path" do
       helper(:tmp_path) { @tmp_path ||= Pathname.new(Dir.mktmpdir) }


### PR DESCRIPTION
When we use custom context_scope and Padrino is defined rabl will try
execute 'resolve_template' method from Padrino on custom context_scope. We
need to check that context_scope has defined method 'resolve_template'

Issue related to https://github.com/LTe/grape-rabl/issues/17
