### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Continuous Integration status](https://secure.travis-ci.org/nesquena/rabl.png)](http://travis-ci.org/nesquena/rabl)
 [![Dependency Status](https://gemnasium.com/nesquena/rabl.png)](https://gemnasium.com/nesquena/rabl)
+[![Code Climate](https://codeclimate.com/github/nesquena/rabl.png)](https://codeclimate.com/github/nesquena/rabl)
 
 RABL (Ruby API Builder Language) is a Rails and [Padrino](http://padrinorb.com) ruby templating system for generating JSON, XML, MessagePack, PList and BSON.
 When using the ActiveRecord 'to_json' method, I find myself wanting a more expressive and powerful solution for generating APIs.


### PR DESCRIPTION
Hello,

It looks like someone (maybe you) added RABL to Code Climate a little while back, and I thought you might want to know.

I work at Code Climate and we do automated code reviews for Ruby using static analysis. It's free for OSS, and your metrics live here:

https://codeclimate.com/github/nesquena/rabl

In case you want this information to be available to contributors, this PR just adds a dynamic badge to the README (similar to Travis and Gemnasium) that displays the code quality GPA

If you have any questions, let me know.

I hope you find Code Climate useful.

Best -

Noah
