### PR TITLE
Send engine options from render call

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -36,7 +36,7 @@ module Rabl
         instance_eval(@_source) if @_source.present?
       end
       instance_exec(@_data_object, &block) if block_given?
-      cache_results { self.send("to_" + @_options[:format].to_s) }
+      cache_results { self.send("to_" + @_options[:format].to_s, @_options) }
     end
 
     # Returns a hash representation of the data object


### PR DESCRIPTION
This change send the `@_options` instance variable to to_ :format method.

This arose when using the code below. In this case, an options hash is supported, but never used when rendering.

```
Rabl::Renderer.json(activity, template_path(activity), root: false)
```
