### PR TITLE
Set default root_object lazily.

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -27,9 +27,12 @@ module Rabl
       return unless data_token # nil or false
       return data_token.values.first if data_token.is_a?(Hash) # @user => :user
       data = data_object(data_token)
-      if is_collection?(data) && data.respond_to?(:first) # data is a collection
+      if is_collection?(data) # data is a collection
         object_name = data.table_name if data.respond_to?(:table_name)
-        object_name ||= data_name(data.first).to_s.pluralize if data.first.present?
+        if !object_name && data.respond_to?(:first)
+          first = data.first
+          object_name = data_name(first).to_s.pluralize if first.present?
+        end
         object_name ||= data_token if data_token.is_a?(Symbol)
         object_name
       elsif is_object?(data) # data is an object


### PR DESCRIPTION
I made this change to my own fork which didn't have 20bfde21e55ed2b4fcf147c6026f9e53ee177d84, because I was seeing `Engine#render` call `Helpers#data_name(default_object)` call `data.first` _twice_ when `@whatevers` contains a collection, which would result in two unnecessary queries. This is no longer the case in master because of the mentioned commit, but I thought lazy setting of the default would be nicer anyway.
