### PR TITLE
fix stack level too deep error when digesting recurisve templates

### DIFF
--- a/lib/rabl/digestor.rb
+++ b/lib/rabl/digestor.rb
@@ -5,7 +5,8 @@ module Rabl
     def self.digest(name, format, finder, options = {})
       cache_key = [name, format] + Array.wrap(options[:dependencies])
       @@cache[cache_key.join('.')] ||= begin
-        @@cache[cache_key.join('.')] = ''  # Prevent re-entry if recursive template exists
+        # Prevent re-entry (and infinite loop) when digesting a recursive template.
+        @@cache[cache_key.join('.')] = ''
         Digestor.new(name, format, finder, options).digest
       end
     end


### PR DESCRIPTION
I have a RABL template which sometimes extends itself in a `child` block.

With caching enabled, this blew the stack with an infinite recursion. 

I made the smallest change I could to prevent that from happening.

Note however that this has been fixed in a more complete way in `ActionView::Digestor`, which has also been updated to be thread safe (see here: https://github.com/rails/rails/pull/11664).

This patch should thus be seen as a temporary solution until the updated code can be integrated from `ActionView::Digestor`. I haven't done that myself because I didn't want to mess with code I don't know well.
