### PR TITLE
Adds exclude_empty_values_in_collections option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,11 @@ Rabl.configure do |config|
   # config.raise_on_missing_attribute = true # Defaults to false
   # config.replace_nil_values_with_empty_strings = true # Defaults to false
   # config.exclude_nil_values = true # Defaults to false
+  # config.exclude_empty_values_in_collections = true # Defaults to false
 end
 ```
 
-Each option specifies behavior related to RABL's output. 
+Each option specifies behavior related to RABL's output.
 
 If `include_json_root` is disabled that removes the root node for each root object in the output, and `enable_json_callbacks` enables support for 'jsonp' style callback
 output if the incoming request has a 'callback' parameter.
@@ -182,6 +183,8 @@ production code is not recommended.
 If `replace_nil_values_with_empty_strings` is set to `true`, all values that are `nil` and would normally be displayed as `null` in the response are converted to empty strings.
 
 If `exclude_nil_values` is set to `true`, all values that are `nil` and would normally be displayed as `null` in the response are not included in the response.
+
+if `exclude_empty_values_in_collections` is set to `true`, all vaules in a collection that are `{}` and would normally be displayed as `{}` in the response are not included in the response.
 
 If you wish to use [oj](https://github.com/ohler55/oj) as
 the primary JSON encoding engine simply add that to your Gemfile:

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -49,6 +49,7 @@ module Rabl
     attr_accessor :perform_caching
     attr_accessor :replace_nil_values_with_empty_strings
     attr_accessor :exclude_nil_values
+    attr_accessor :exclude_empty_values_in_collections
 
     DEFAULT_XML_OPTIONS = { :dasherize  => true, :skip_types => false }
 
@@ -75,6 +76,7 @@ module Rabl
       @perform_caching                       = false
       @replace_nil_values_with_empty_strings = false
       @exclude_nil_values                    = false
+      @exclude_empty_values_in_collections   = false
     end
 
     # @return The JSON engine used to encode Rabl templates into JSON

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -50,7 +50,9 @@ module Rabl
       if is_object?(data) || !data # object @user
         builder.build(data, options)
       elsif is_collection?(data) # collection @users
-        data.map { |object| builder.build(object, options) }
+        result = data.map { |object| builder.build(object, options) }
+        result = result.map(&:presence).compact if Rabl.configuration.exclude_empty_values_in_collections
+        result
       end
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -15,6 +15,7 @@ context 'Rabl::Configuration' do
     asserts(:cache_engine).is_a?(Rabl::CacheEngine)
     asserts(:replace_nil_values_with_empty_strings).equals false
     asserts(:exclude_nil_values).equals false
+    asserts(:exclude_empty_values_in_collections).equals false
   end
 
   context 'custom JSON engine configured as Symbol' do
@@ -66,4 +67,14 @@ context 'Rabl::Configuration' do
 
     asserts(:exclude_nil_values).equals true
   end # exclude nil values
+
+  context 'exclude empty values in collections' do
+    setup do
+      Rabl.configure do |c|
+        c.exclude_empty_values_in_collections = true
+      end
+    end
+
+    asserts(:exclude_empty_values_in_collections).equals true
+  end # exclude empty values in collections
 end


### PR DESCRIPTION
This adds `config.exclude_empty_values_in_collections`
This will remove any empty hash returned when building a collection. This is useful when you catch errors in an index.rabl.  For instance when trying to be robust about sub-entities that may be missing.  When loading a feed of items, if a related entity is not found, the main feed item can be excluded from the list.  You could check whether each sub-item exists when building the collection in the controller instead, but then you would not be leveraging the caching per-item in the rabl.  To do this in a way that leverages caching while also being robust about bad references, you need this setting.

```
collection @feed_items

node do |feed_item|
  begin
    partial 'shared/feed/show.json', object: feed_item
  rescue ActiveRecord::RecordNotFound => e
    nil
  end
end
```

**TODO:**
- Add specs that test exclude_empty_values_in_collections is really removing values. I am not sure how to run the specs locally so any help with that would be awesome.
