### PR TITLE
Fixes bug with string values being replaced by nil

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -61,7 +61,7 @@ module Rabl
 
     def replace_empty_string_values
       @_result = @_result.inject({}) do |hash, (k, v)|
-        hash[k] = v.try(:empty?) ? nil : v
+        hash[k] = (!v.nil? && v != "") ? v : nil
         hash
       end
     end

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -70,6 +70,10 @@ context "Rabl::Builder" do
         topic.build(User.new(:name => nil))
       end.equivalent_to({ :name => nil })
 
+      asserts "that it handles existing non nil values correctly" do
+        topic.build(User.new(:name => 10))
+      end.equivalent_to({ :name => 10 })
+
       teardown do
         Rabl.configuration.replace_empty_string_values_with_nil_values = false
       end


### PR DESCRIPTION
Just realized there was a bug that wouldn't accept existing integers or whatever value that `empty?` threw a `NoMethodError` on. This should fix it 
