### PR TITLE
Update ActionView::Digestor#digest for rails 4.1.0

### DIFF
--- a/lib/rabl/digestor.rb
+++ b/lib/rabl/digestor.rb
@@ -2,17 +2,30 @@ module Rabl
   class Digestor < ActionView::Digestor
     # Override the original digest function to ignore partial which
     # rabl doesn't use the Rails conventional _ symbol.
-    def self.digest(name, format, finder, options = {})
-      cache_key = [name, format] + Array.wrap(options[:dependencies])
-      @@cache[cache_key.join('.')] ||= begin
-        Digestor.new(name, format, finder, options).digest
+    if Rails.version.to_s >= '4.1'
+      def self.digest(options = {})
+        cache_key = [options[:name]] + Array.wrap(options[:dependencies])
+        @@cache[cache_key.join('.')] ||= begin
+          Digestor.new({ name: options[:name], finder: options[:finder] }.merge!(options)).digest
+        end
+      end
+    else
+      def self.digest(name, format, finder, options = {})
+        cache_key = [name, format] + Array.wrap(options[:dependencies])
+        @@cache[cache_key.join('.')] ||= begin
+          Digestor.new(name, format, finder, options).digest
+        end
       end
     end
 
     private
       def dependency_digest
         template_digests = dependencies.collect do |template_name|
-          Digestor.digest(template_name, format, finder)
+          if Rails.version.to_s >= '4.1'
+            Digestor.digest(name: template_name, finder: finder)
+          else
+            Digestor.digest(template_name, format, finder)
+          end
         end
 
         (template_digests + injected_dependencies).join("-")

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -288,10 +288,17 @@ module Rabl
 
     def cache_key_with_digest(cache_key)
       template = @_options[:template] || @virtual_path
+
+      if Rails.version.to_s >= '4.1'
+        digested =  Digestor.digest(name: template, finder: lookup_context)
+      else
+        digested = Digestor.digest(template, :rabl, lookup_context)
+      end
+
       Array(cache_key) + [
         @_options[:root_name],
         @_options[:format],
-        Digestor.digest(template, :rabl, lookup_context)
+        digested
       ]
     rescue NameError => e # Handle case where lookup_context doesn't exist
       raise e unless e.message =~ /lookup_context/


### PR DESCRIPTION
format is not passed as an argument anymore and it only takes a hash
instead of 4 arguments

See https://github.com/rails/rails/commit/767a2b009c07c5c3e4b77a77942f11701f1d8858

This help us get a green build on spree api. I'm not sure what could be the caveats for rabl of not using the format any more. Will try to investigate that later on and setup some spec for it. Just want to bring this to you attention guys to see if the change is safe / makes sense.
