### PR TITLE
Set cache key to data object when using undefined variable

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -151,6 +151,7 @@ module Rabl
     # options is passed through to the cache store
     def cache(key = nil, options = nil)
       key ||= root_object # if called but missing, use object
+      key.map! { |o| o.nil? ? @_data_object : o  } if key.is_a?(Array)
       @_cache = [key, options]
     end
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -57,6 +57,22 @@ context "Rabl::Engine" do
 
       denies(:instance_variable_defined?, :@_cache)
     end
+
+    context "undefined object" do
+      setup do
+        template = rabl %q{
+          object @user
+          cache ['foo', @users]
+        }
+        @user = User.new
+        scope = Object.new
+        scope.instance_variable_set :@user, @user
+        template.render(scope)
+        template.instance_eval('@engine')
+      end
+
+      asserts_topic.assigns(:_cache) { [['foo', @user], nil] }
+    end
   end
 
   context "with defaults" do


### PR DESCRIPTION
Currently when you want to use a cache key prefix and use `extends`  will cause an empty cache key.

For example:
# sites/index

``` ruby
collection @sites
extends 'resources/sites/show'
```
# sites/show

``` ruby
object @site
cache ["prefix", @site]

attributes :id, :name
```

In the `show` template `@site` is undefined and therefor cache key can't find an object to call `cache_key` on.
