### PR TITLE
Convert attribute, node, child string keys/names to symbols

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -99,7 +99,9 @@ module Rabl
     # attribute :foo, :as => "bar", :if => lambda { |m| m.foo }
     def attribute(name, options={})
       if @_object && attribute_present?(name) && resolve_condition(options)
-        @_result[options[:as] || name] = data_object_attribute(name)
+        attribute = data_object_attribute(name)
+        name = (options[:as] || name).to_sym
+        @_result[name] = attribute
       end
     end
     alias_method :attributes, :attribute
@@ -111,7 +113,7 @@ module Rabl
       return unless resolve_condition(options)
       result = block.call(@_object)
       if name.present?
-        @_result[name] = result
+        @_result[name.to_sym] = result
       elsif result.respond_to?(:each_pair) # merge hash into root hash
         @_result.merge!(result)
       end
@@ -130,7 +132,7 @@ module Rabl
       engine_options = @options.slice(:child_root).merge(:root => include_root)
       engine_options.merge!(:object_root_name => options[:object_root]) if is_name_value?(options[:object_root])
       object = { object => name } if data.respond_to?(:each_pair) && object # child :users => :people
-      @_result[name] = self.object_to_hash(object, engine_options, &block)
+      @_result[name.to_sym] = self.object_to_hash(object, engine_options, &block)
     end
 
     # Glues data from a child node to the json_output

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -115,6 +115,20 @@ context "Rabl::Builder" do
         end.raises(RuntimeError)
       end
     end
+
+    context "that with a string key" do
+      setup { builder({ :attributes => { "name" => {} } }) }
+      asserts "the node name is converted to a symbol" do
+        topic.build(User.new, :name => "user")
+      end.equivalent_to({ :name => "rabl" })
+    end
+
+    context "that with the same node names as strings and symbols" do
+      setup { builder({ :attributes => { "name" => {}, :name => {} } }) }
+      asserts "the nodes aren't duplicated" do
+        topic.build(User.new, :name => "user")
+      end.equivalent_to({ :name => "rabl" })
+    end
   end
 
   context "#node" do
@@ -128,6 +142,17 @@ context "Rabl::Builder" do
         { :name => :baz, :options => {}, :block => lambda { |u| u.city } }
       ]
     end.equivalent_to({:foo => 'bar', :baz => 'irvine'})
+
+    asserts "that it converts the node name to a symbol" do
+      build_hash @user, :node => [{ :name => "foo", :options => {}, :block => lambda { |u| "bar" } }]
+    end.equivalent_to({:foo => 'bar'})
+
+    asserts "that the same node names as a string and symbol aren't duplicated" do
+      build_hash @user, :node => [
+        { :name => "foo", :options => {}, :block => lambda { |u| "bar" } },
+        { :name => :foo, :options => {}, :block => lambda { |u| "bar" } }
+      ]
+    end.equivalent_to({:foo => 'bar'})
   end
 
   context "#child" do
@@ -172,6 +197,19 @@ context "Rabl::Builder" do
       mock(b).object_to_hash(@users, { :root => "person", :object_root_name => "person", :child_root => true }).returns('xyz').subject
       b.build(@user)
     end.equivalent_to({ :people => 'xyz'})
+
+    asserts "that it converts the child name to a symbol" do
+      b = builder(:child => [ { :data => { @user => "user" }, :options => { }, :block => lambda { |u| attribute :name } } ])
+      b.build(@user)
+    end.equivalent_to({ :user => { :name => "rabl" } })
+
+    asserts "that it does't duplicate childs with the same name as a string and symbol" do
+      b = builder(:child => [
+        { :data => { @user => "user" }, :options => { }, :block => lambda { |u| attribute :name } },
+        { :data => { @user => :user }, :options => { }, :block => lambda { |u| attribute :name } }
+      ])
+      b.build(@user)
+    end.equivalent_to({ :user => { :name => "rabl" } })
   end
 
   context "#glue" do


### PR DESCRIPTION
This is a PR in reference to this issue https://github.com/nesquena/rabl/issues/549. Fixes inconsistencies with how different JSON engines deal with duplicate keys as strings and symbols. Most of the faster JSON engines I tested (Yajl and OJ) don't care and will let these pass through. ActiveSupport::JSON is the outlier that will de-duplicate by converting all keys to symbols first.
