### PR TITLE
Fix passing locals to extends

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -316,7 +316,7 @@ module Rabl
       @_locals, @_scope = locals, scope
       self.copy_instance_variables_from(@_scope, [:@assigns, :@helpers])
       set_locals(locals)
-      set_source(&block)
+      set_source(locals, &block)
     end
 
     def set_locals(locals)
@@ -324,7 +324,7 @@ module Rabl
       locals.each { |k,v| instance_variable_set(:"@#{k}", v) }
     end
 
-    def set_source(&block)
+    def set_source(locals, &block)
       return unless @_source.present?
 
       if @_options[:source_location]

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -708,6 +708,7 @@ context "Rabl::Engine" do
         File.open(tmp_path + "test.json.rabl", "w") do |f|
           f.puts %q{
             attributes :age
+            node(:city) { "Gotham" } if locals[:show_city]
           }
         end
       end
@@ -722,6 +723,17 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@user, User.new(:name => 'leo', :age => 12)
         JSON.parse(template.render(scope))
       end.equals JSON.parse("{\"name\":\"leo\",\"age\":12}")
+
+      asserts "that it can be passed locals" do
+        template = rabl %{
+          object @user
+          attribute :name
+          extends 'test', :locals => { :show_city => true }
+        }
+        scope = Object.new
+        scope.instance_variable_set :@user, User.new(:name => 'leo', :age => 12)
+        JSON.parse(template.render(scope))
+      end.equals JSON.parse("{\"name\":\"leo\",\"age\":12,\"city\":\"Gotham\"}")
 
       asserts "that it can be passed conditionals" do
         template = rabl %{


### PR DESCRIPTION
Pull Request #545 broke passing locals to `extends`. Specifically commit 2abc390e650ba6bce19a5575d291550e80815bc2. This also adds a test that was failing.
