### PR TITLE
Add fallback for child name if its nil

### DIFF
--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -41,6 +41,8 @@ module Rabl
         object_name ||= collection_root_name.to_s.singularize if collection_root_name
         object_name ||= data.class.respond_to?(:model_name) ? data.class.model_name.element : data.class.to_s.downcase
         object_name
+      else
+        data_token
       end
     end
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -302,7 +302,7 @@ context "Rabl::Engine" do
         template.render(scope)
       end.equals "{\"user\":{\"name\":\"leo\",\"users\":[{\"user\":{\"city\":\"UNO\"}},{\"user\":{\"city\":\"DOS\"}}]}}"
 
-      asserts "child chooses name based on symbol if no elements" do
+      asserts "that it chooses a name based on symbol if no elements" do
         template = rabl %{
           object @bar => :bar
           child(:foos) { attribute :city }
@@ -313,6 +313,18 @@ context "Rabl::Engine" do
         scope.instance_variable_set :@bar, bar
         template.render(scope)
       end.equals "{\"bar\":{\"foos\":[]}}"
+
+      asserts "that it chooses a name based on symbol if nil" do
+        template = rabl %{
+          object @bar => :bar
+          child(:foos) { attribute :city }
+        }
+        scope = Object.new
+        bar = Object.new
+        stub(bar).foos { nil }
+        scope.instance_variable_set :@bar, bar
+        template.render(scope)
+      end.equals "{\"bar\":{\"foos\":null}}"
 
       asserts "it allows suppression of root node for child collection" do
         template = rabl %{


### PR DESCRIPTION
If a child's data was `nil`, no condition would apply in `data_name`. This adds a fallback to just return `data_token` if all else fails.

Added a test would previously fail. That test case would actually produce a _blank_ key before:

`"{\"bar\":{\"\":null}}"`

edit: Forgot to mention that this was made worse by my #551 PR since `to_sym` would error on `nil`.
