### PR TITLE
Fix non default request formats

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -269,7 +269,6 @@ module Rabl
       @_options[:extends] = []
       @_options[:root_name]  = nil
       @_options[:scope] = scope
-      @_options[:format] ||= self.request_format
     end
 
     # Caches the results of the block based on object cache_key
@@ -315,6 +314,7 @@ module Rabl
     def set_instance_variables!(scope, locals, &block)
       @_locals, @_scope = locals, scope
       self.copy_instance_variables_from(@_scope, [:@assigns, :@helpers])
+      @_options[:format] ||= self.request_format
       set_locals(locals)
       set_source(locals, &block)
     end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -23,6 +23,30 @@ context "Rabl::Engine" do
     asserts_topic.assigns :_view_path
   end
 
+  context "#request_format" do
+    context "is json by default" do
+      setup do
+        template = RablTemplate.new("code") { "" }
+        template.render(Object.new)
+        engine = template.instance_eval('@engine')
+        engine.instance_eval('@_options')[:format]
+      end
+
+      asserts_topic.equals('json')
+    end
+
+    context "with a specified format" do
+      setup do
+        template = RablTemplate.new("code", format: 'xml') { "" }
+        template.render(Object.new)
+        engine = template.instance_eval('@engine')
+        engine.instance_eval('@_options')[:format]
+      end
+
+      asserts_topic.equals('xml')
+    end
+  end
+
   context "#cache" do
     context "with cache" do
       setup do


### PR DESCRIPTION
The request format is set before the request instance variables, causing
all rendered templates to use the default request format.

Fixes #560.
