### PR TITLE
use ruby 1.8 hash format for compatibility

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -292,7 +292,7 @@ module Rabl
       template = @_options[:template] || @virtual_path
 
       if Rails.version.to_s >= '4.1'
-        digested =  Digestor.digest(name: template, finder: lookup_context)
+        digested =  Digestor.digest(:name => template, :finder => lookup_context)
       else
         digested = Digestor.digest(template, :rabl, lookup_context)
       end


### PR DESCRIPTION
I'm sure there's not a lot of sympathy for supporting such old versions of Ruby but have pity on us poor souls stuck there...
