### PR TITLE
Fix Rabl::Tracker to match paths with numbers

### DIFF
--- a/lib/rabl/tracker.rb
+++ b/lib/rabl/tracker.rb
@@ -6,7 +6,7 @@ module Rabl
     EXTENDS_DEPENDENCY = /
       extends\s*              # extends, followed by optional whitespace
       \(?                     # start an optional parenthesis for the extends call
-      \s*["']([a-z_\/\.]+)    # the template name itself
+      \s*["']([0-9a-z_\/\.]+) # the template name itself
     /x
 
     # Matches:
@@ -14,7 +14,7 @@ module Rabl
     PARTIAL_DEPENDENCY = /
       partial\s*              # partial, followed by optional whitespace
       \(?                     # start an optional parenthesis for the partial call
-      \s*["']([a-z_\/\.]+)    # the template name itself
+      \s*["']([0-9a-z_\/\.]+) # the template name itself
     /x
 
     def self.call(name, template)


### PR DESCRIPTION
It fixes finding dependencies for paths with numbers like `partial("v1/posts")` etc. Currently in such case Rails outputs a a cryptic warning `Couldn't find template for digesting: v` and only for the first request that uses caching, so it's really easy to overlook it.

I haven't written any tests, because there are no tests for `Rabl::Tracker` yet at all and I couldn't figure out how to create a template that could be passed to tracker object. I tried creating a `RablTemplate`, but it complained that it doesn't have `source` method.
