### PR TITLE
Another version string fix, also 1.8 hash syntax

### DIFF
--- a/lib/rabl/digestor.rb
+++ b/lib/rabl/digestor.rb
@@ -2,11 +2,11 @@ module Rabl
   class Digestor < ActionView::Digestor
     # Override the original digest function to ignore partial which
     # rabl doesn't use the Rails conventional _ symbol.
-    if Rails.version.to_s >= '4.1'
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('4.1')
       def self.digest(options = {})
         cache_key = [options[:name]] + Array.wrap(options[:dependencies])
         @@cache[cache_key.join('.')] ||= begin
-          Digestor.new({ name: options[:name], finder: options[:finder] }.merge!(options)).digest
+          Digestor.new({ :name => options[:name], :finder => options[:finder] }.merge!(options)).digest
         end
       end
     else
@@ -21,8 +21,8 @@ module Rabl
     private
       def dependency_digest
         template_digests = dependencies.collect do |template_name|
-          if Rails.version.to_s >= '4.1'
-            Digestor.digest(name: template_name, finder: finder)
+          if Gem::Version.new(Rails.version) >= Gem::Version.new('4.1')
+            Digestor.digest(:name => template_name, :finder => finder)
           else
             Digestor.digest(template_name, format, finder)
           end


### PR DESCRIPTION
Apologies for not fixing all the version checks in the last pull request.

This also includes a fix for the ruby 1.8 hash syntax to be consistent with the rest of the project.
