### PR TITLE
Fixed: Caching a recursive template 

### DIFF
--- a/lib/rabl/digestor.rb
+++ b/lib/rabl/digestor.rb
@@ -20,7 +20,7 @@ module Rabl
 
     private
       def dependency_digest
-        template_digests = dependencies.collect do |template_name|
+        template_digests = (dependencies - [template.virtual_path]).collect do |template_name|
           if Gem::Version.new(Rails.version) >= Gem::Version.new('4.1')
             Digestor.digest(:name => template_name, :finder => finder)
           else


### PR DESCRIPTION
(ex: an object with children that recursively renders it's children) would cause the template to include itself in it's own dependencies, creating an infinite loop and a 'stack level too deep' response.

For instance, a template like this (called 'test'):
object @user
cache @user
child kids: :kids do
    extends 'test'
 end

I spent a couple hours trying to write a failing test but cannot get the integration tests to work and perform_caching is false in the model tests. 
