### PR TITLE
fix cache for Non-Rails app

### DIFF
--- a/fixtures/sinatra_test/app.rb
+++ b/fixtures/sinatra_test/app.rb
@@ -16,6 +16,9 @@ Dir[File.dirname(__FILE__) + "/models/*.rb"].each do |file|
 end
 
 # Register RABL
+Rabl.configure do |config|
+  config.perform_caching = true
+end
 Rabl.register!
 
 class SinatraTest < Sinatra::Application

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -277,15 +277,19 @@ module Rabl
       _cache = @_cache if defined?(@_cache)
       cache_key, cache_options = *_cache || nil
       if template_cache_configured? && cache_key
-        if Rails.version =~ /^[4]/
-          result_cache_key = cache_key_with_digest(cache_key)
-        else # fallback for Rails 3
-          result_cache_key = cache_key_simple(cache_key)
+        result_cache_key = if digestor_available?
+          cache_key_with_digest(cache_key)
+        else # fallback for Rails 3, and Non-Rails app
+          cache_key_simple(cache_key)
         end
         fetch_result_from_cache(result_cache_key, cache_options, &block)
       else # skip caching
         yield
       end
+    end
+
+    def digestor_available?
+      defined?(Rails) && Rails.version =~ /^[4]/
     end
 
     def cache_key_with_digest(cache_key)


### PR DESCRIPTION
It seems from RABL version 0.9.0, cache doesn't work on Non-Rails app (e.g., Sinatra).
"NameError: uninitialized constant Rabl::Engine::Rails" raised.

Enabling cache on "fixtures/sinatra_test/app.rb" will reproduce this error.
This patch fixes this problem and enables cache on sinatra again.
