### PR TITLE
Return partial as engine with given view_path

### DIFF
--- a/lib/rabl/partials.rb
+++ b/lib/rabl/partials.rb
@@ -7,7 +7,7 @@ module Rabl
       raise ArgumentError, "Must provide an :object option to render a partial" unless options.has_key?(:object)
 
       object    = options.delete(:object)
-      view_path = options[:view_path] || view_path
+      view_path = options[:view_path] || self.view_path
 
       source, location = fetch_source(file, :view_path => view_path)
 

--- a/test/partials_test.rb
+++ b/test/partials_test.rb
@@ -89,6 +89,26 @@ context "Rabl::Partials" do
     end
   end
 
+  context "partial_as_engine using configured view paths" do
+    helper(:tmp_path) { @tmp_path ||= Pathname.new(Dir.mktmpdir) }
+
+    setup do
+      File.open(tmp_path + "_test.rabl", "w")
+      engine = Rabl::Engine.new('', :view_path => tmp_path)
+    end
+
+    asserts('returns new engine with given view_path') do
+      topic.partial_as_engine('test', :object => {}).view_path
+    end.equals do
+      tmp_path
+    end
+
+    teardown do
+      Rabl.configuration.view_paths = []
+    end
+  end
+
+
   context "fetch source with custom scope" do
     context "when Padrino is defined" do
       helper(:tmp_path) { @tmp_path ||= Pathname.new(Dir.mktmpdir) }


### PR DESCRIPTION
There was problem with `view_path` method. This method under normal
circumstances will returns `@_view_path` instance variable. Here comes
an interesting behavior of ruby

``` ruby
def view_path
   true
end

view_path = nil || view_path
view_path # => nil
```

Ruby will initialize non-existed local_variable and override the
method with the same name. So there is no way to create engine with
given `view_path`.
