### PR TITLE
Check if context_scope includes `.settings.views`

### DIFF
--- a/lib/rabl/sources.rb
+++ b/lib/rabl/sources.rb
@@ -14,7 +14,7 @@ module Rabl
           elsif defined?(Rails) && context_scope.respond_to?(:view_paths)
             _view_paths = view_paths + Array(context_scope.view_paths.to_a)
             fetch_rails_source(file, options) || fetch_manual_template(_view_paths, file)
-          elsif defined?(Sinatra) && context_scope.respond_to?(:settings)
+          elsif defined?(Sinatra) && context_scope.respond_to?(:settings) && context_scope.settings.respond_to?(:views)
             fetch_sinatra_source(file, options)
           else # generic template resolution
             fetch_manual_template(view_paths, file)

--- a/test/partials_test.rb
+++ b/test/partials_test.rb
@@ -133,6 +133,30 @@ context "Rabl::Partials" do
 
       teardown { Object.send(:remove_const, :Padrino) }
     end
+
+    context "when Sinatra is defined" do
+      helper(:tmp_path) { @tmp_path ||= Pathname.new(Dir.mktmpdir) }
+
+      setup do
+        ::Sinatra = stub(Class.new)
+        Rabl.configuration.cache_sources = false
+        @it = TestPartial.new
+
+        def @it.context_scope; @context_scope ||= Object.new; end
+        context_scope = @it.context_scope
+        def context_scope.settings; @settings ||= Object.new end
+
+        File.open(tmp_path + "test.json.rabl", "w") { |f| f.puts "content" }
+      end
+
+      asserts('Sinatra constant dont break manual lookup') do
+        @it.fetch_source((tmp_path + "test").to_s)
+      end.equals do
+        ["content\n", "/" + (tmp_path + "test.json.rabl").to_s ]
+      end
+
+      teardown { Object.send(:remove_const, :Sinatra) }
+    end
   end
 
   context "fetch source with Rails" do


### PR DESCRIPTION
When Sinatra is defined rabl assume that `context_scope` is from
Sinatra. We need to check that context_scope includes whole path.

Related: #597
