### PR TITLE
Suppress warning from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in rabl.gemspec
 gemspec
 
-gem 'rake', :require => false
 gem 'i18n', '~> 0.6'
 
 platforms :mri_18 do
@@ -12,7 +11,7 @@ platforms :mri_18 do
 end
 
 group :test do
-  # RABL TEST  
+  # RABL TEST
   gem 'builder'
 
   # FIXTURES


### PR DESCRIPTION
```
Your Gemfile lists the gem rake (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
```
