### PR TITLE
Remove a dead link from tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,6 @@ Tutorials can always be helpful when first getting started:
  * http://blog.joshsoftware.com/2011/12/23/designing-rails-api-using-rabl-and-devise/
  * http://engineering.gomiso.com/2011/06/27/building-a-platform-api-on-rails/
  * http://blog.lawrencenorton.com/better-json-requests-with-rabl
- * http://www.rodrigoalvesvieira.com/developing-json-api-rails-rabl/
  * http://tech.favoritemedium.com/2011/06/using-rabl-in-rails-json-web-api.html
  * http://seesparkbox.com/foundry/better_rails_apis_with_rabl
  * http://blog.dcxn.com/2011/06/22/rails-json-templates-through-rabl


### PR DESCRIPTION
Looks like this domain has gone away, and now it's just a domain-for-sale page.