### PR TITLE
Use empty hash as default cache options

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -213,7 +213,7 @@ module Rabl
     # cache                  # uses the current item within a collection
     # cache 'user', expires_in: 1.hour
     # options is passed through to the cache store
-    def cache(key = nil, options = nil)
+    def cache(key = nil, options = {})
       key ||= root_object # if called but missing, use object
       @_cache_key     = key
       @_cache_options = options

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -138,12 +138,12 @@ module Rabl
 
     # Fetches a key from the cache and stores rabl template result otherwise
     # fetch_from_cache('some_key') { ...rabl template result... }
-    def fetch_result_from_cache(cache_key, cache_options = nil, &block)
+    def fetch_result_from_cache(cache_key, cache_options = {}, &block)
       expanded_cache_key = ActiveSupport::Cache.expand_cache_key(cache_key, :rabl)
       Rabl.configuration.cache_engine.fetch(expanded_cache_key, cache_options, &block)
     end
 
-    def write_result_to_cache(cache_key, cache_options = nil, &block)
+    def write_result_to_cache(cache_key, cache_options = {}, &block)
       expanded_cache_key = ActiveSupport::Cache.expand_cache_key(cache_key, :rabl)
       result = yield
       Rabl.configuration.cache_engine.write(expanded_cache_key, result, cache_options)


### PR DESCRIPTION
It's a hash of options and it makes more sense to default with a hash as well.

Moreover, it fixes an issue I'm having where the `readthis` Gem expects a hash at https://github.com/sorentwo/readthis/blob/f2bf22550958ad0232d6537e3029127c8339a82f/lib/readthis/cache.rb#L148

---

That said, I'm not sure whether this should be fixed in Rabl since [ActiveSupport::Cache::Store](http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch) uses `nil` as the default. Please let me know if you reckon `readthis` should handle the `nil` case instead and I'll send a PR there.