### PR TITLE
Filter rabl results in request (like Facebook Graph API 2.0)

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -15,6 +15,8 @@ require 'rabl/multi_builder'
 require 'rabl/configuration'
 require 'rabl/renderer'
 require 'rabl/cache_engine'
+require 'rabl/filter'
+require 'rabl/filter_field'
 
 if defined?(Rails)
   require 'rabl/tracker'  if Rails.version =~ /^[4]/

--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -138,12 +138,12 @@ module Rabl
       def attribute(name, options = {})
         return unless @_object && attribute_present?(name) && resolve_condition(options)
 
-        name = (options[:as] || name).to_sym
-
         # returns if not included in fields
         return if not @filters.blank? and not @filters.has_filter_for? name
 
         attribute = data_object_attribute(name)
+        name = (options[:as] || name).to_sym
+
         @_result[name] = attribute
       end
       alias_method :attributes, :attribute

--- a/lib/rabl/configuration.rb
+++ b/lib/rabl/configuration.rb
@@ -52,6 +52,7 @@ module Rabl
     attr_accessor :replace_empty_string_values_with_nil_values
     attr_accessor :exclude_nil_values
     attr_accessor :exclude_empty_values_in_collections
+    attr_accessor :filter_fields_from_request
 
     DEFAULT_XML_OPTIONS = { :dasherize  => true, :skip_types => false }
 
@@ -81,6 +82,7 @@ module Rabl
       @replace_empty_string_values_with_nil_values  = false
       @exclude_nil_values                           = false
       @exclude_empty_values_in_collections          = false
+      @filter_fields_from_request                   = false
     end
 
     # @return The JSON engine used to encode Rabl templates into JSON

--- a/lib/rabl/filter.rb
+++ b/lib/rabl/filter.rb
@@ -1,0 +1,58 @@
+module Rabl
+  # @attr_reader [Rabl::Engine] engine
+  class Filter
+    attr_reader :fields, :parent
+
+    def initialize(query_string, parent=nil)
+      @query_string = query_string
+      @parent       = parent
+      parse_filter
+    end
+
+    def has_filter_for?(node)
+      get_filter(node) != nil
+    end
+
+    def get_filter(node)
+      @fields.find {|f| f.node.to_sym == node.to_sym }
+    end
+
+    def execute_functions_in(object, from)
+      if has_filter_for? from and not get_filter(from).functions.blank?
+        filter = get_filter(from)
+        regexp_fns = Regexp.new '(\.?(?<fn>' + functions_permitted + ')\((?<params>[^\)]*)\))'
+        scan = filter.functions.scan regexp_fns
+        scan.each do |fn|
+          object = object.send(function_methods[fn[0].to_sym], fn[1]) if object.respond_to? fn[0]
+        end
+      end
+      object
+    end
+
+    protected
+
+    def parse_filter
+      @fields = parser @query_string
+    end
+
+    def parser(fields)
+      regexp = Regexp.new '((?<node>\w+)(?<functions>(\.(' + functions_permitted + ')\(([\w ]+)\))*)(\{(?<fields>.+)\})*),?'
+      content = fields.to_s.scan regexp
+      content.collect {|c| FilterField.new(c[0], c[1], c[2], parent)}
+    end
+
+    def functions_permitted
+      [
+          :limit,
+          :sort
+      ].join '|'
+    end
+
+    def function_methods
+      {
+          limit: :limit,
+          sort: :order
+      }
+    end
+  end
+end

--- a/lib/rabl/filter_field.rb
+++ b/lib/rabl/filter_field.rb
@@ -1,0 +1,26 @@
+module Rabl
+  class FilterField
+
+    attr_reader :node
+    attr_reader :functions
+    attr_reader :fields
+    attr_reader :parent
+
+    def initialize(node, functions, fields, parent=nil)
+      @node      = node
+      @functions = functions
+      @fields    = fields
+      @parent    = parent
+
+      if not @fields.blank?
+        @fields = Filter.new @fields, parent_name
+      end
+    end
+
+    protected
+
+    def parent_name
+      node.to_s.underscore.to_sym
+    end
+  end
+end

--- a/lib/rabl/multi_builder.rb
+++ b/lib/rabl/multi_builder.rb
@@ -5,9 +5,10 @@ module Rabl
     # Constructs a new MultiBuilder given the data and options.
     # The options will be re-used for all Rabl::Builders.
     # Rabl::MultiBuilder.new([#<User ...>, #<User ...>, ...], { :format => 'json', :child_root => true })   
-    def initialize(data, settings = {}, options = {})
+    def initialize(data, settings = {}, options = {}, filters = [], parent=nil)
       @data                 = data
       @settings             = settings
+      @filters              = filters
       @options              = options
       @builders             = []
       @engine_to_builder    = {}
@@ -36,7 +37,7 @@ module Rabl
     # the builders generated
     def generate_builders
       @builders = @data.map do |object|
-        Builder.new(object, @settings, @options)
+        Builder.new(object, @settings, @options, @filters)
       end
     end
 

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -175,7 +175,7 @@ context "Rabl::Builder" do
       e = Rabl::Engine.new('')
       mock(b).data_name(@user) { :user }
       mock(e).render.returns('xyz')
-      mock(b).object_to_engine(@user, { :root => false }).returns(e).subject
+      mock(b).object_to_engine(@user, { :root => false, filters:false }).returns(e).subject
       b.to_hash(@user)
     end.equivalent_to({ :user => 'xyz'})
 
@@ -184,7 +184,7 @@ context "Rabl::Builder" do
       e = Rabl::Engine.new('')
       mock(b).data_name(@users) { :users }
       mock(e).render.returns('xyz')
-      mock(b).object_to_engine(@users, { :root => true, :child_root => true }).returns(e).subject
+      mock(b).object_to_engine(@users, { :root => true, :child_root => true, filters:false }).returns(e).subject
       b.to_hash(@user)
     end.equivalent_to({ :users => 'xyz'})
 
@@ -193,7 +193,7 @@ context "Rabl::Builder" do
       e = Rabl::Engine.new('')
       mock(b).data_name(@users) { :users }
       mock(e).render.returns('xyz')
-      mock(b).object_to_engine(@users, { :root => false, :child_root => false }).returns(e).subject
+      mock(b).object_to_engine(@users, { :root => false, :child_root => false, filters:false }).returns(e).subject
       b.to_hash(@user)
     end.equivalent_to({ :users => 'xyz'})
 
@@ -202,7 +202,7 @@ context "Rabl::Builder" do
       b = builder nil, { :child => [{ :data => @users, :options => ops, :block => lambda { |u| attribute :name } }] }, { :child_root => true }
       e = Rabl::Engine.new('')
       mock(e).render.returns('xyz')
-      mock(b).object_to_engine(@users, { :root => "person", :object_root_name => "person", :child_root => true }).returns(e).subject
+      mock(b).object_to_engine(@users, { :root => "person", :object_root_name => "person", :child_root => true, filters:false }).returns(e).subject
       b.to_hash(@user)
     end.equivalent_to({ :people => 'xyz'})
 


### PR DESCRIPTION
We developed a new feature for rabl. With it we can filter the results displayed by the resutl of a request, like the one facebook uses on its [Graph Api Explorer](https://developers.facebook.com/tools/explorer).

Given a resource that has something like...  id, name, address, albums, timestamps and other relationships would be a hassle to return only what you want from it, checking for fields to display or creating multiple templates. We built a way that you can get what you want, on the request:

`http://api.com/resource?fields=name,id,albums.limit(5).sort(name){id,name,photos.limit(10){id,url}}`


And the rendered JSON template would be something like:

```ruby
[
    {
         "id" : 1,
        "name" : "Zaez",
        "albums" : [
            {
                "id" : 1,
                "name" : "Summer Pictures",
                "photos":[
                    {
                        "id" : 1,
                        "url": "http://images.com..."
                    },
                    # ... 9 more times
                ]
            },
           # ... 4 more times
        ]
    },
   # ... n times
]
```

This process was made to work without modifying anything in the way templating works in RABL.  What do you guys think? Is that interesting enough to warrant a pull request?

The only issue we're having right now is that we're not used to write unit tests that can give a meaningful result for our implementation so we'd like a bit of help with that.