### PR TITLE
Check that the Rails module has the .version method before invocation

### DIFF
--- a/lib/rabl/template.rb
+++ b/lib/rabl/template.rb
@@ -20,7 +20,7 @@ if defined?(Tilt)
 end
 
 # Rails 2.X Template
-if defined?(ActionView) && defined?(Rails) && Rails.version.to_s =~ /^2/
+if defined?(ActionView) && defined?(Rails) && Rails.respond_to?(:version) && Rails.version.to_s =~ /^2/
   require 'action_view/base'
   require 'action_view/template'
 
@@ -41,7 +41,7 @@ if defined?(ActionView) && defined?(Rails) && Rails.version.to_s =~ /^2/
 end
 
 # Rails 3.X / 4.X Template
-if defined?(ActionView) && defined?(Rails) && Rails.version.to_s =~ /^[34]/
+if defined?(ActionView) && defined?(Rails) && Rails.respond_to?(:version) && Rails.version.to_s =~ /^[34]/
   module ActionView
     module Template::Handlers
       class Rabl


### PR DESCRIPTION
 - This is an issue when in a Sinatra project that uses rabl and ActionView::Helpers::NumberHelper but none of the other Rails components

Prior to this change a developer would see this error:

```bash
/usr/local/rvm/gems/ruby-2.1.1/gems/rabl-0.11.6/lib/rabl/template.rb:23:in `<top (required)>': undefined method `version' for Rails:Module (NoMethodError)
```