### PR TITLE
add rails5 support

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -17,9 +17,9 @@ require 'rabl/renderer'
 require 'rabl/cache_engine'
 
 if defined?(Rails)
-  require 'rabl/tracker'  if Rails.version =~ /^[4]/
-  require 'rabl/digestor' if Rails.version =~ /^[4]/
-  require 'rabl/railtie'  if Rails.version =~ /^[34]/
+  require 'rabl/tracker'  if Rails.version =~ /^[45]/
+  require 'rabl/digestor' if Rails.version =~ /^[45]/
+  require 'rabl/railtie'  if Rails.version =~ /^[345]/
 end
 
 # Rabl.register!

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -16,7 +16,7 @@ module Rabl
 
       @_view_path     = options[:view_path]
       @_context_scope = options[:scope]
-      
+
       @_cache_read_on_render = true
     end
 
@@ -94,7 +94,7 @@ module Rabl
     end
 
     def to_dumpable(options = {})
-      options = { 
+      options = {
         :child_root => Rabl.configuration.include_child_root
       }.merge(options)
 
@@ -132,7 +132,7 @@ module Rabl
     # to_xml(:root => true)
     def to_xml(options = {})
       options = {
-        :root       => (include_root = Rabl.configuration.include_xml_root), 
+        :root       => (include_root = Rabl.configuration.include_xml_root),
         :child_root => include_root && Rabl.configuration.include_child_root
       }.merge(options)
 
@@ -228,12 +228,12 @@ module Rabl
         attr_aliases  = args.first.except(:if, :unless)
         conditions    = args.first.slice(:if, :unless)
 
-        attr_aliases.each do |key, as| 
+        attr_aliases.each do |key, as|
           attribute(key, conditions.merge(:as => as))
         end
       else # array of attributes i.e :foo, :bar, :baz
         options = args.extract_options!
-        args.each do |name| 
+        args.each do |name|
           @_settings[:attributes] << { :name => name, :options => options }
         end
       end
@@ -389,7 +389,7 @@ module Rabl
       end
 
       def digestor_available?
-        defined?(Rails) && Rails.version =~ /^[4]/
+        defined?(Rails) && Rails.version =~ /^[45]/
       end
 
       def set_instance_variables!(context_scope, locals)
@@ -410,7 +410,7 @@ module Rabl
 
       def eval_source(locals, &block)
         # Note: locals and block may be used by the eval'ed source
-        
+
         return unless @_source.present?
 
         if @_options[:source_location]

--- a/lib/rabl/railtie.rb
+++ b/lib/rabl/railtie.rb
@@ -5,7 +5,7 @@ module Rabl
         Rabl.register!
 
         # Inject dependency tracker for :rabl
-        if Rails.version =~ /^[4]/
+        if Rails.version =~ /^[45]/
           require 'action_view/dependency_tracker'
           ActionView::DependencyTracker.register_tracker :rabl, Rabl::Tracker
         end

--- a/lib/rabl/template.rb
+++ b/lib/rabl/template.rb
@@ -41,7 +41,7 @@ if defined?(ActionView) && defined?(Rails) && Rails.version.to_s =~ /^2/
 end
 
 # Rails 3.X / 4.X Template
-if defined?(ActionView) && defined?(Rails) && Rails.version.to_s =~ /^[34]/
+if defined?(ActionView) && defined?(Rails) && Rails.version.to_s =~ /^[345]/
   module ActionView
     module Template::Handlers
       class Rabl


### PR DESCRIPTION
Rails 5.0.0.beta1 has been released, but rabl is checking for Rails Versions that start with 4 to hook into rails. 

This adds 5 to the checks for the rails version so that rabl hooks into Rails 5 apps.
