### PR TITLE
[#649] Compatibility with ruby 2.3.0

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -199,7 +199,7 @@ module Rabl
       # Evaluate conditions given a symbol/proc/lambda/variable to evaluate
       def call_condition_proc(condition, object)
         # This will evaluate lambda, proc & symbol and call it with 1 argument
-        return condition.to_proc.call(object) if condition.respond_to?(:to_proc)
+        return condition.to_proc.call(object) if condition.is_a?(Proc) || condition.is_a?(Symbol)
         # Else we send directly the object
         condition
       end

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -353,5 +353,10 @@ context "Rabl::Builder" do
       scope = Rabl::Builder.new(ArbObj.new)
       scope.send(:resolve_condition, { :if => nil })
     end.equals(nil)
+
+    asserts "that it can use a hash variable on if condition and return true" do
+      scope = Rabl::Builder.new(ArbObj.new)
+      scope.send(:resolve_condition, { :if => { some: 'data' } })
+    end.equals(nil)
   end
 end


### PR DESCRIPTION
Fix two issue I raised in the following GH issue: #649

- remove duck typing on `:to_proc`
- check type for Symbol/Proc