### PR TITLE
Fix syntax in Rabl::CacheEngine#read_multi for MRI 1.8.7

### DIFF
--- a/lib/rabl/cache_engine.rb
+++ b/lib/rabl/cache_engine.rb
@@ -28,10 +28,10 @@ module Rabl
     end
 
     def read_multi(*keys)
-      options = keys.extract_options!
       if defined?(Rails)
-        Rails.cache.read_multi(*keys, options)
+        Rails.cache.read_multi(*keys)
       else
+        options = keys.extract_options!
         keys.inject({}) { |hash, key| hash[key] = nil; hash }
       end
     end


### PR DESCRIPTION
MRI 1.8.7 finds the existing syntax problematic (throws a `SyntaxError`). This simple refactor makes the syntax 1.8.7 acceptable, without any functionality regressions. 

Additionally, I've tested the `Rabl::CacheEngine#read_multi` method on various Ruby/Rails versions:
Ruby 1.8.7 + Rails 2.3
Ruby 1.9.3 + Rails 3.1
Ruby 1.9.3 + Rails 4.2.6
Ruby 2.3.0 + Rails 5 (beta)

And I haven't noticed any issues, the behaviour is the same.
