### PR TITLE
fix test from #649

### DIFF
--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -357,6 +357,6 @@ context "Rabl::Builder" do
     asserts "that it can use a hash variable on if condition and return true" do
       scope = Rabl::Builder.new(ArbObj.new)
       scope.send(:resolve_condition, { :if => { some: 'data' } })
-    end.equals(nil)
+    end.equals({some: 'data'})
   end
 end


### PR DESCRIPTION
The test added from #649 seems to return the hash {some: data} and not nil as it is expected now.
Right now, the test fails in my environment with the following error:
```
Rabl::Builder #resolve_conditionals asserts that it can use a hash variable on if condition and return true => expected nil, not {:some=>"data"}
```
This PR is fixing this. Now the tests pass in my environment with Ruby 2.3