### PR TITLE
Performance tuning

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -15,7 +15,7 @@ module Rabl
     # options = { :format => "json", :root => true, :child_root => true,
     #   :attributes, :node, :child, :glue, :extends }
     #
-    def initialize(object, settings = {}, options = {}, &block)
+    def initialize(object, settings = {}, options = {})
       @_object = object
 
       @settings       = settings
@@ -41,7 +41,7 @@ module Rabl
       engines[engines.index(engine)] = value
     end
 
-    def to_hash(object = nil, settings = {}, options = {})
+    def to_hash(object = nil, settings = nil, options = nil)
       @_object = object           if object
       @options.merge!(options)    if options
       @settings.merge!(settings)  if settings
@@ -168,9 +168,9 @@ module Rabl
         name   = is_name_value?(options[:root]) ? options[:root] : data_name(data)
         object = data_object(data)
 
-        include_root = is_collection?(object) && options.fetch(:object_root, @options[:child_root]) # child @users
-        engine_options = @options.slice(:child_root).merge(:root => include_root)
-        engine_options.merge!(:object_root_name => options[:object_root]) if is_name_value?(options[:object_root])
+        engine_options = @options.slice(:child_root)
+        engine_options[:root] = is_collection?(object) && options.fetch(:object_root, @options[:child_root]) # child @users
+        engine_options[:object_root_name] = options[:object_root] if is_name_value?(options[:object_root])
 
         object = { object => name } if data.is_a?(Hash) && object # child :users => :people
 
@@ -192,7 +192,7 @@ module Rabl
       def extends(file, options = {}, &block)
         return unless resolve_condition(options)
 
-        options = @options.slice(:child_root).merge(:object => @_object).merge(options)
+        options = @options.slice(:child_root).merge!(:object => @_object).merge!(options)
         engines << partial_as_engine(file, options, &block)
       end
 

--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -75,7 +75,7 @@ module Rabl
     # Returns a hash representation of the data object
     # to_hash(:root => true, :child_root => true)
     def to_hash(options = {})
-      options = @_options.merge(options)
+      options.reverse_merge!(@_options)
 
       data = root_object
 
@@ -94,9 +94,7 @@ module Rabl
     end
 
     def to_dumpable(options = {})
-      options = {
-        :child_root => Rabl.configuration.include_child_root
-      }.merge(options)
+      options.reverse_merge!({ :child_root => Rabl.configuration.include_child_root })
 
       result = to_hash(options)
       result = { collection_root_name => result } if collection_root_name
@@ -106,7 +104,7 @@ module Rabl
     # Returns a json representation of the data object
     # to_json(:root => true)
     def to_json(options = {})
-      options = { :root => Rabl.configuration.include_json_root }.merge(options)
+      options.reverse_merge!({ :root => Rabl.configuration.include_json_root })
       result = to_dumpable(options)
       format_json(result)
     end
@@ -263,7 +261,7 @@ module Rabl
     # Extends an existing rabl template with additional attributes in the block
     # extends("users/show", :object => @user) { attribute :full_name }
     def extends(file, options = {}, &block)
-      options = { :view_path => options[:view_path] || view_path }.merge(options)
+      options.reverse_merge!({ :view_path => options[:view_path] || view_path })
 
       @_settings[:extends] << { :file => file, :options => options, :block => block }
     end
@@ -357,7 +355,7 @@ module Rabl
       end
 
       def copy_instance_variables_from(object, exclude = []) #:nodoc:
-        vars = object.instance_variables.map(&:to_s) - exclude.map(&:to_s)
+        vars = object.instance_variables - exclude
         vars.each { |name| instance_variable_set(name, object.instance_variable_get(name)) }
       end
 

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -123,12 +123,12 @@ module Rabl
     def object_to_engine(object, options = {}, &block)
       return if object.nil?
 
-      options = { 
-        :format     => "hash", 
-        :view_path  => view_path, 
+      options.reverse_merge!({
+        :format     => "hash".freeze,
+        :view_path  => view_path,
         :root       => (options[:root] || false)
-      }.merge(options)
-      
+      })
+
       Engine.new(options[:source], options).apply(context_scope, :object => object, :locals => options[:locals], &block)
     end
 

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -1,11 +1,7 @@
 require 'active_support/inflector' # for the sake of pluralizing
-require 'set'
 
 module Rabl
   module Helpers
-    # Set of class names known to be objects, not collections
-    KNOWN_OBJECT_CLASSES = Set.new(['Struct', 'Hashie::Mash'])
-
     # data_object(data) => <AR Object>
     # data_object(@user => :person) => @user
     # data_object(:user => :person) => @_object.send(:user)
@@ -86,7 +82,7 @@ module Rabl
     def is_collection?(obj, follow_symbols = true)
       data_obj = follow_symbols ? data_object(obj) : obj
       data_obj && data_obj.respond_to?(:map) && data_obj.respond_to?(:each) &&
-        obj.class.ancestors.none? { |a| KNOWN_OBJECT_CLASSES.include?(a.name) }
+        !(data_obj.is_a?(Struct) || defined?(Hashie::Mash) && data_obj.is_a?(Hashie::Mash))
     end
 
     # Returns the context_scope wrapping this engine, used for retrieving data, invoking methods, etc

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -122,9 +122,15 @@ context "Rabl::Helpers" do
       @helper_class.is_collection?([@user])
     end.equals(true)
 
-    asserts "returns true for an array" do
+    asserts "returns false for a Hashie::Mash with 1 key" do
       obj = Hashie::Mash.new({:name => 'hello'})
       @helper_class.is_collection?(obj)
     end.equals(false)
+
+    asserts "returns false for a Hashie::Mash with 2 keys" do
+      obj = Hashie::Mash.new({:name => 'hello', :key2 => 'key2'})
+      @helper_class.is_collection?(obj)
+    end.equals(false)
+
   end # is_collection method
 end


### PR DESCRIPTION
I've been looking into the performance of Rabl to see where we could get some speedups without making major changes. The performance of any output obviously depends a lot how much data is being rendered and how complex the templates are. With the changes in this PR, I'm seeing a **50% speed improvement** and **50% less memory allocated** for pretty simple JSON response (10 records with 2 attributes plus a child array of 5 each with 2 attributes) using a simple template with a `child` for an array. Benchmark script and results below.

The code currently allocates a lot of strings and hashes which can be eliminated. The main changes in this PR are:
* Eliminate string allocations from `is_collection?` Calling `ancestors` on ActiveRecord objects can return 30+ classes which all need to be converted to strings. And `is_collection?` gets called a lot.
* Eliminate string allocations from `copy_instance_variables_from`
* Use `merge!` and `reverse_merge!` to eliminate Hash allocations
* Freeze just one string in a hotspot

The benchmark script I've been using is here... https://gist.github.com/dgynn/57eb21e89cdfa84a6aa66d90844487dd
You can run that against this PR branch and modify it for different template scenarios.

Rabl template from the benchmark script...
```
collection @posts
attributes :id, :title
child :comments, :object_root => false do
  attribute :id, :text
end
```

Before
```
Warming up --------------------------------------
        render posts    55.000  i/100ms
Calculating -------------------------------------
        render posts    567.502  (± 3.7%) i/s -      2.860k in   5.047086s

Total allocated: 1885229 bytes (26301 objects)
Total retained:  400 bytes (10 objects)
```
After
```
Warming up --------------------------------------
        render posts    81.000  i/100ms
Calculating -------------------------------------
        render posts    796.711  (± 4.8%) i/s -      4.050k in   5.095444s

Total allocated: 1039789 bytes (9761 objects)
Total retained:  400 bytes (10 objects)
```