### PR TITLE
Fix travis by upgrading bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
-# http://about.travis-ci.org/docs/user/build-configuration/
+# https://docs.travis-ci.com/user/customizing-the-build/
+language: ruby
+cache: bundler
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.1
 notifications:
   recipients:
     - nesquena@gmail.com
     - databyte@gmail.com
-matrix:
-  allow_failures:
-    - rvm: 1.8.7
+before_install:
+  - gem install bundler


### PR DESCRIPTION
I believe adding `gem install bundler` should resolve the Travis failures. (See https://github.com/bundler/bundler/issues/3560) I was able to recreate the failure and then resolve it with this commit.

This commit also drops ruby 1.8.7. There are tests that have syntax that requires 1.9 which will always fail so there is no point in running them.

I've also created another branch that runs the `test:fixtures` rake task instead of just `test`.
https://github.com/dgynn/rabl/tree/travis_with_fixtures
That branch is failing for various reasons although the majority of the tests pass for different combinations of Ruby and the frameworks/Gemfiles. The branch also drops support for Rails 2.x. Since those tests are failing I didn't want to make a PR for them but you can see the output here... https://travis-ci.org/dgynn/rabl/builds/137428066
