### PR TITLE
Fix Digestor errors on rails 5

### DIFF
--- a/lib/rabl/digestor/rails5.rb
+++ b/lib/rabl/digestor/rails5.rb
@@ -1,31 +1,4 @@
 module Rabl
   class Digestor < ActionView::Digestor
-    @@digest_monitor = Mutex.new
-
-    def self.digest(name:, finder:, **options)
-
-      options.assert_valid_keys(:dependencies, :partial)
-
-      cache_key = ([ name ].compact + Array.wrap(options[:dependencies])).join('.')
-
-      # this is a correctly done double-checked locking idiom
-      # (Concurrent::Map's lookups have volatile semantics)
-      finder.digest_cache[cache_key] || @@digest_monitor.synchronize do
-        finder.digest_cache.fetch(cache_key) do # re-check under lock
-          begin
-            # Prevent re-entry or else recursive templates will blow the stack.
-            # There is no need to worry about other threads seeing the +false+ value,
-            # as they will then have to wait for this thread to let go of the @@digest_monitor lock.
-
-            pre_stored = finder.digest_cache.put_if_absent(cache_key, false).nil? # put_if_absent returns nil on insertion
-
-            finder.digest_cache[cache_key] = stored_digest = Digestor.new(name, finder, options).digest
-          ensure
-            # something went wrong or ActionView::Resolver.caching? is false, make sure not to corrupt the @@cache
-            finder.digest_cache.delete_pair(cache_key, false) if pre_stored && !stored_digest
-          end
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
On rails 5 with caching enabled, rabl encounters errors in the digestor

```
wrong number of arguments (3 for 0) occured
```

@databyte sums this up well in [#653](https://github.com/nesquena/rabl/pull/653#issuecomment-233051722)

> In an interactive debug session, I basically get to `Digestor.new` and it throws `wrong number of arguments (3 for 0) occured` for `Digestor.new(name, finder, options).digest`. [...]
> The Rails 5 Digestor doesn't have an initializer and the 3rd parameter is actually the dependencies and not the options.

We're already calling `Digestor.digest` with the same signature as the built-in digest, so we should just use that.