### PR TITLE
fix caching for rails 5

### DIFF
--- a/lib/rabl/digestor/rails5.rb
+++ b/lib/rabl/digestor/rails5.rb
@@ -19,7 +19,7 @@ module Rabl
 
             pre_stored = finder.digest_cache.put_if_absent(cache_key, false).nil? # put_if_absent returns nil on insertion
 
-            finder.digest_cache[cache_key] = stored_digest = Digestor.new(name, finder, options).digest
+            finder.digest_cache[cache_key] = stored_digest = super(name: name, finder: finder, dependencies: options)
           ensure
             # something went wrong or ActionView::Resolver.caching? is false, make sure not to corrupt the @@cache
             finder.digest_cache.delete_pair(cache_key, false) if pre_stored && !stored_digest


### PR DESCRIPTION
`ActionView::Digestor` does not have an initializer.  The class methods
available are `digest`, `logger`, and `tree`.  Reading the documentation
makes me think that `Rabl::Digestor` should just call `super` to get
back to the necessary method.
