### PR TITLE
Duplicate locals hash when setting instance vars

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -27,6 +27,8 @@ module Rabl
     # Renders the representation based on source, object, context_scope and locals
     # Rabl::Engine.new("...source...", { :format => "xml" }).apply(context_scope, { :foo => "bar", :object => @user })
     def apply(context_scope, locals, &block)
+      locals = locals.dup unless locals.nil?
+
       set_instance_variables!(context_scope, locals)
 
       reset_settings!

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -23,6 +23,12 @@ context "Rabl::Engine" do
     asserts_topic.assigns :_view_path
   end
 
+  context "#apply" do
+    denies("that it raises exception when given frozen locals").raises(RuntimeError) do
+      Rabl::Engine.new("").apply(Object.new, {}.freeze)
+    end
+  end
+
   context "#request_format" do
     context "is json by default" do
       setup do


### PR DESCRIPTION
The Rabl engine mutates the locals hash when using it to set the instance variables for template rendering, this causes a `RuntimeError` when a frozen hash is passed.

Currently this requires a workaround to use Rabl as an engine with Roda's render plugin.

This fix also ensures the general case that might not be perceived currently due to local workarounds.  

See: https://github.com/jeremyevans/roda/issues/115