### PR TITLE
Fixed check for rails version

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -83,6 +83,6 @@ end
 if defined?(Padrino)
   require 'padrino-core'
   Padrino.after_load { Rabl.register! }
-elsif defined?(Rails) && Rails.version =~ /^2/
+elsif defined?(Rails.version) && Rails.version =~ /^2/
   Rabl.register!
 end


### PR DESCRIPTION
Check of rails version should also take into account that module presence is not guarantee the `version` presence.