### PR TITLE
Remove broken link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,6 @@ Tutorials can always be helpful when first getting started:
 
  * [Railscasts #322](http://railscasts.com/episodes/322-rabl) - Ryan Bates explains RABL
  * [BackboneRails](http://www.backbonerails.com/) - Great screencasts by Brian Mann
- * [Creating an API with RABL and Padrino](http://blog.crowdint.com/2012/10/22/rabl-with-padrino.html)
  * http://blog.joshsoftware.com/2011/12/23/designing-rails-api-using-rabl-and-devise/
  * http://engineering.gomiso.com/2011/06/27/building-a-platform-api-on-rails/
  * http://blog.lawrencenorton.com/better-json-requests-with-rabl


### PR DESCRIPTION
The link can no longer be found, and I cannot find where it has moved to
(if it has moved at all)

Sneaky documentation commit for Hacktoberfest ;)