### PR TITLE
Support new Ruby 2.4 and 2.5 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.5
-  - 2.3.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 notifications:
   recipients:
     - nesquena@gmail.com

--- a/rabl.gemspec
+++ b/rabl.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'tilt'
   s.add_development_dependency 'oj'
-  s.add_development_dependency 'msgpack',  '~> 0.4.5'
+  s.add_development_dependency 'msgpack',  '~> 1.0.0'
   s.add_development_dependency 'bson',     '~> 1.7.0'
   s.add_development_dependency 'plist'
 end


### PR DESCRIPTION
- Update development requirement of `msgpack` to `1.0.x` for Ruby `2.4` and `2.5` support
- [CI] Auto test on 2.x patched versions