### PR TITLE
Remove deadlinks from tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,11 +628,8 @@ Tutorials can always be helpful when first getting started:
  * [Railscasts #322](http://railscasts.com/episodes/322-rabl) - Ryan Bates explains RABL
  * [BackboneRails](http://www.backbonerails.com/) - Great screencasts by Brian Mann
  * http://blog.joshsoftware.com/2011/12/23/designing-rails-api-using-rabl-and-devise/
- * http://engineering.gomiso.com/2011/06/27/building-a-platform-api-on-rails/
- * http://blog.lawrencenorton.com/better-json-requests-with-rabl
  * http://tech.favoritemedium.com/2011/06/using-rabl-in-rails-json-web-api.html
  * http://seesparkbox.com/foundry/better_rails_apis_with_rabl
- * http://blog.dcxn.com/2011/06/22/rails-json-templates-through-rabl
  * http://teohm.github.com/blog/2011/05/31/using-rabl-in-rails-json-web-api
 
 Let me know if there's any other useful resources not listed here.


### PR DESCRIPTION
There's a few broken links in the tutorials section. This commit takes care of those. 
I also verified the sanity of the rest of the links in the file.