### PR TITLE
README / Example Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,11 +583,11 @@ You can also pass in other instance variables to be used in your template as:
 Rabl::Renderer.new('posts/show', @post, :locals => { :custom_title => "Hello world!" })
 ````
 
-Then, in your template, you can use `@custom_title` as:
+Then, in your template, you can use `locals[:custom_title]` as:
 
-```
+```ruby
 attribute :content
-node(:title) { @custom_title }
+node(:title) { locals[:custom_title] }
 ```
 
 ### Content Type Headers ###


### PR DESCRIPTION
Fix incorrect example around usage of partials.

In my implementation I noticed that I couldn't access local variables by using an instance variable, however accessing the `locals` hash seems to work correctly (and is used elsewhere in the documentation). 