### PR TITLE
Make tests run on Ruby 2.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,11 @@ Rake::TestTask.new(:test) do |test|
   test.pattern = 'test/*_test.rb'
   test.warning = true
   test.verbose = true
-  test.ruby_opts = ['-rubygems']
+  if RUBY_VERSION < "1.9.0"
+    # -rubygems isn't needed as of 1.9, and is gone as of 2.5
+    # https://github.com/ruby/ruby/blob/v2_5_0/NEWS#stdlib-compatibility-issues-excluding-feature-bug-fixes
+    test.ruby_opts = ['-rubygems']
+  end
 end
 
 # Running integration tests


### PR DESCRIPTION
There was an obsolete flag being passed to the test command.

I've removed the flag only for versions of ruby >= 1.9. That's when this flag became unnecessary, and it was removed with ruby 2.5.

See Ruby release notes for 2.5 at:
https://github.com/ruby/ruby/blob/v2_5_0/NEWS#stdlib-compatibility-issues-excluding-feature-bug-fixes

The short suite of tests passes on 2.5 with this change.

I was not able to get the full suite of integration tests to run, with either Ruby 2.4 or 2.5. I did follow all the steps in the Rakefile (`rake test:clean; rake test:setup; rake test:full`) Is this still something that's used for this project?