### PR TITLE
Define `silence_stream` in the test helper when it is missing (rails5 tests)

### DIFF
--- a/test/silence.rb
+++ b/test/silence.rb
@@ -3,6 +3,15 @@ module Kernel
     with_warnings(nil) { yield }
   end
 
+  def with_warnings(flag)
+    old_verbose, $VERBOSE = $VERBOSE, flag
+    yield
+  ensure
+    $VERBOSE = old_verbose
+  end
+end unless Kernel.respond_to? :silence_warnings
+
+module Kernel
   def silence_stream(stream)
     old_stream = stream.dup
     stream.reopen(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
@@ -11,11 +20,4 @@ module Kernel
   ensure
     stream.reopen(old_stream)
   end
-
-  def with_warnings(flag)
-    old_verbose, $VERBOSE = $VERBOSE, flag
-    yield
-  ensure
-    $VERBOSE = old_verbose
-  end
-end unless Kernel.respond_to? :silence_warnings
+end unless Kernel.respond_to? :silence_stream


### PR DESCRIPTION
**Description**

There are versions of rails that define `silence_warnings` but don't define `silence_stream` (eg. the latest version of rails 5: https://github.com/rails/rails/blob/5-0-stable/activesupport/lib/active_support/core_ext/kernel/reporting.rb ).
The previous code was only checking the presence of `silence_warnings` to decide to skip the definition of both `silence_warnings` and `silence_stream`, so in the case of latest rails 5.0.* the tests were failing because `silence_stream` was missing.

**How to reproduce**

```
cd fixtures/rails5
bundle exec rake test
--------------------------------------------------------------------------------
Warning from RR:
  RR::Adapters::RRMethods is deprecated;
  please use RR::DSL instead.

Called from:
 - /home/roberto/.rvm/gems/ruby-2.5.3/gems/riot-0.12.7/lib/riot/rr.rb:12:in `include'
 - /home/roberto/.rvm/gems/ruby-2.5.3/gems/riot-0.12.7/lib/riot/rr.rb:12:in `<class:Situation>'
 - /home/roberto/.rvm/gems/ruby-2.5.3/gems/riot-0.12.7/lib/riot/rr.rb:11:in `<module:RR>'
--------------------------------------------------------------------------------
rake aborted!
NoMethodError: undefined method `silence_stream' for main:Object
Did you mean?  silence_warnings
/home/roberto/projects/rabl/fixtures/rails5/test/test_helper.rb:15:in `<top (required)>'
/home/roberto/projects/rabl/fixtures/rails5/test/functional/posts_controller_test.rb:7:in `require'
...
```