### PR TITLE
gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rabl.gemspec
+++ b/rabl.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = %q{General ruby templating with json, bson, xml and msgpack support}
   s.license     = 'MIT'
 
-  s.rubyforge_project = "rabl"
-
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.