### PR TITLE
Fix Rails 4.2 regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master (unreleased)
+
+* Fix regression on Rails 4.2 (@tagliala)
+
 ## 0.14.2 (September 10th, 2019)
 
 * Made Rails 6 compatible (@jpawlyn)

--- a/lib/rabl/helpers.rb
+++ b/lib/rabl/helpers.rb
@@ -84,7 +84,7 @@ module Rabl
     def is_collection?(obj, follow_symbols = true)
       data_obj = follow_symbols ? data_object(obj) : obj
       data_obj &&
-        data_obj.is_a?(Enumerable) &&
+        data_obj.respond_to?(:map) && data_obj.respond_to?(:each) &&
         !(data_obj.is_a?(Struct) ||
           defined?(Hashie::Mash) && data_obj.is_a?(Hashie::Mash))
     end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -114,6 +114,16 @@ context "Rabl::Helpers" do
       @helper_class.is_collection?(obj.new)
     end.equals(false)
 
+    asserts "returns false for an object with map" do
+      obj = Class.new { def map; end }
+      @helper_class.is_collection?(obj.new)
+    end.equals(false)
+
+    asserts "returns true for an object with each and map" do
+      obj = Class.new { def each; end; def map; end }
+      @helper_class.is_collection?(obj.new)
+    end.equals(true)
+
     asserts "returns false for a hash alias" do
       @helper_class.is_collection?(@user => :user)
     end.equals(false)


### PR DESCRIPTION
Rails 4’s ActiveRecord_Relation responds to both `:map` and `:each`, but
it is not an `Enumerable`

This commit partially restores the old behavior

Ref: 
- #721
- 4cf2c667a8f05eb5e04abf371c0978f6604574ab