### PR TITLE
Remove not required files from the .gem

### DIFF
--- a/rabl.gemspec
+++ b/rabl.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{General ruby templating with json, bson, xml and msgpack support}
   s.license     = 'MIT'
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files -z -- {*.md,MIT-LICENSE,lib}`.split("\x0").sort
   s.require_paths = ["lib"]
 
 


### PR DESCRIPTION
To make the .gem smaller and lighter remove the tests, fixtures, and examples.

At the fixture and tests has many symlinks and this makes very complicated on Open Source Code Scanner because these links broke after installing the gem, this way these files will not be at the production environments and make the gem more clear.
