### PR TITLE
Source cache and digestors thread-safety

### DIFF
--- a/lib/rabl/cache_engine.rb
+++ b/lib/rabl/cache_engine.rb
@@ -31,6 +31,7 @@ module Rabl
     def initialize
       unless defined?(Rails)
         @cache = LRU.new
+        @mutex = Mutex.new
       end
     end
 
@@ -44,7 +45,9 @@ module Rabl
       if defined?(Rails)
         Rails.cache.fetch(key, cache_options, &block)
       else
-        @cache[key] ||= yield
+        @mutex.synchronize do
+          @cache[key] ||= yield
+        end
       end
     end
 
@@ -52,7 +55,9 @@ module Rabl
       if defined?(Rails)
         Rails.cache.write(key, value, options)
       else
-        @cache[key] = yield
+        @mutex.synchronize do
+          @cache[key] = yield
+        end
       end
     end
 

--- a/lib/rabl/digestor/rails3.rb
+++ b/lib/rabl/digestor/rails3.rb
@@ -1,9 +1,13 @@
 module Rabl
   class Digestor < ActionView::Digestor
+    @@rabl_mutex = Mutex.new
+
     def self.digest(name, format, finder, options = {})
       cache_key = [name, format] + Array.wrap(options[:dependencies])
-      @@cache[cache_key.join('.')] ||= begin
-        Digestor.new(name, format, finder, options).digest
+      @@rabl_mutex.synchronize do
+        @@cache[cache_key.join('.')] ||= begin
+          Digestor.new(name, format, finder, options).digest
+        end
       end
     end
   end

--- a/lib/rabl/digestor/rails41.rb
+++ b/lib/rabl/digestor/rails41.rb
@@ -1,9 +1,13 @@
 module Rabl
   class Digestor < ActionView::Digestor
+    @@rabl_mutex = Mutex.new
+
     def self.digest(options = {})
       cache_key = [options[:name]] + Array.wrap(options[:dependencies])
-      @@cache[cache_key.join('.')] ||= begin
-        Digestor.new({ :name => options[:name], :finder => options[:finder] }.merge!(options)).digest
+      @@rabl_mutex.synchronize do
+        @@cache[cache_key.join('.')] ||= begin
+          Digestor.new({ :name => options[:name], :finder => options[:finder] }.merge!(options)).digest
+        end
       end
     end
   end


### PR DESCRIPTION
Source cache is a global hash, this is an attempt to fix a problem in our codebase when multiple update requests are getting random template rendered when `create.json.rabl` is missing.