### PR TITLE
Require action_view for ActionView::Digestor

### DIFF
--- a/lib/rabl/digestor.rb
+++ b/lib/rabl/digestor.rb
@@ -1,3 +1,5 @@
+require 'action_view'
+
 module Rabl
   class Digestor < ActionView::Digestor
     # Override the original digest function to ignore partial which

--- a/lib/rabl/digestor/rails3.rb
+++ b/lib/rabl/digestor/rails3.rb
@@ -1,3 +1,5 @@
+require 'action_view'
+
 module Rabl
   class Digestor < ActionView::Digestor
     def self.digest(name, format, finder, options = {})

--- a/lib/rabl/digestor/rails41.rb
+++ b/lib/rabl/digestor/rails41.rb
@@ -1,3 +1,5 @@
+require 'action_view'
+
 module Rabl
   class Digestor < ActionView::Digestor
     def self.digest(options = {})

--- a/lib/rabl/digestor/rails5.rb
+++ b/lib/rabl/digestor/rails5.rb
@@ -1,3 +1,5 @@
+require 'action_view'
+
 module Rabl
   class Digestor < ActionView::Digestor
   end


### PR DESCRIPTION
We're seeing this error when running a binstub of a command from another gem.

```
.rvm/gems/ruby-2.7.4@zenpayroll/gems/rabl-0.14.5/lib/rabl/digestor.rb:2:in `<module:Rabl>': uninitialized constant Rabl::ActionView (NameError)
Did you mean?  ActionMailer
```