### PR TITLE
Avoid loading `ActionController::API` constant

### DIFF
--- a/lib/rabl/railtie.rb
+++ b/lib/rabl/railtie.rb
@@ -10,11 +10,9 @@ module Rabl
           end
         end
 
-        ActiveSupport.on_load :action_controller do
-          if self == ActionController::API
-            include ActionController::Helpers
-            include ActionController::ImplicitRender
-          end
+        ActiveSupport.on_load :action_controller_api do
+          include ActionController::Helpers
+          include ActionController::ImplicitRender
         end
       end
 


### PR DESCRIPTION
Copies https://github.com/rails/jbuilder/pull/529