### PR TITLE
Document Rabl setting `oj`'s mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ or add to your Gemfile:
 # Gemfile
 gem 'rabl'
 # Also add either `oj` or `yajl-ruby` as the JSON parser
+# If using `oj`, Rabl will set the mode to :compat
 gem 'oj'
 ```
 


### PR DESCRIPTION
https://github.com/nesquena/rabl/blob/02b3464a6dfb27a4a34365303974604688d7eb2b/lib/rabl/configuration.rb#L22 is a subtle behavior that's worth calling out, since it can impact other parts of a project that use `oj`.