### PR TITLE
Fix `ArgumentError` when block given with keyword arguments

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -356,8 +356,8 @@ module Rabl
       end
 
       # Supports calling helpers defined for the template context_scope using method_missing hook
-      def method_missing(name, *args, &block)
-        context_scope.respond_to?(name, true) ? context_scope.__send__(name, *args, &block) : super
+      def method_missing(name, *args, **kwargs, &block)
+        context_scope.respond_to?(name, true) ? context_scope.__send__(name, *args, **kwargs, &block) : super
       end
 
       def copy_instance_variables_from(object, exclude = []) #:nodoc:

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -27,6 +27,15 @@ context "Rabl::Engine" do
     denies("that it raises exception when given frozen locals").raises(RuntimeError) do
       Rabl::Engine.new("").apply(Object.new, {}.freeze)
     end
+
+    asserts "that it can call method in block with positional and keyword arguments" do
+      template = RablTemplate.new("code") { 'node(:foo) { func("bar", kw: "baz") }' }
+      obj = Object.new
+      def obj.func(arg, kw:)
+        "#{arg}-#{kw}"
+      end
+      template.render(obj)
+    end.equals "{\"foo\":\"bar-baz\"}"
   end
 
   context "#request_format" do


### PR DESCRIPTION
On Ruby 3.0 or later with Rails, if the following template exists

```app/views/hoge/fuga/index.json.rabl
node(:field) do
  l(Time.now, format: :min)
end
```

then, the following error raised.

```
ArgumentError in Hoge::Fuga#index
Showing /Rails.root/app/views/hoge/fuga/index.json.rabl where line #2 raised:

wrong number of arguments (given 2, expected 1)
```

This is due to a breaking change in the keyword argument in Ruby 3.0.

- [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)