### PR TITLE
Add "except" option to extends

### DIFF
--- a/lib/rabl/builder.rb
+++ b/lib/rabl/builder.rb
@@ -153,6 +153,7 @@ module Rabl
       # node(:foo, :if => lambda { |m| m.foo.present? }) { "bar" }
       def node(name, options = {}, &block)
         return unless resolve_condition(options)
+        return if @options.has_key?(:except) && [@options[:except]].flatten.include?(name)
 
         result = block.call(@_object)
         if name.present?


### PR DESCRIPTION
Our team has the need to `extend` a rabl template `except` for some fields.

```ruby
extends 'foo', except: [:bar, :baz]
```

`except` is a new option, which will exclude the specified fields from the extended template.