### PR TITLE
Fix `ArgumentError` when there are no keyword arguments (Ruby < 2.7)

### DIFF
--- a/lib/rabl/engine.rb
+++ b/lib/rabl/engine.rb
@@ -357,7 +357,13 @@ module Rabl
 
       # Supports calling helpers defined for the template context_scope using method_missing hook
       def method_missing(name, *args, **kwargs, &block)
-        context_scope.respond_to?(name, true) ? context_scope.__send__(name, *args, **kwargs, &block) : super
+        return super unless context_scope.respond_to?(name, true)
+
+        if kwargs.empty?
+          context_scope.__send__(name, *args, &block)
+        else
+          context_scope.__send__(name, *args, **kwargs, &block)
+        end
       end
 
       def copy_instance_variables_from(object, exclude = []) #:nodoc:

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -28,6 +28,24 @@ context "Rabl::Engine" do
       Rabl::Engine.new("").apply(Object.new, {}.freeze)
     end
 
+    asserts "that it can call method in block without arguments" do
+      template = RablTemplate.new("code") { 'node(:foo) { func }' }
+      obj = Object.new
+      def obj.func
+        "bar"
+      end
+      template.render(obj)
+    end.equals "{\"foo\":\"bar\"}"
+
+    asserts "that it can call method in block with positional arguments" do
+      template = RablTemplate.new("code") { 'node(:foo) { func("bar") }' }
+      obj = Object.new
+      def obj.func(arg)
+        "#{arg}"
+      end
+      template.render(obj)
+    end.equals "{\"foo\":\"bar\"}"
+
     asserts "that it can call method in block with positional and keyword arguments" do
       template = RablTemplate.new("code") { 'node(:foo) { func("bar", kw: "baz") }' }
       obj = Object.new


### PR DESCRIPTION
Calling helper methods that are not meant to receive keyword arguments fails with RABL version 0.16.0 and using Ruby < 2.7.

Without the fix, the two new assertions fail.

Here a simple IRB session demonstrating the source of the problem (using Ruby 2.6.10) :

```
object = ::Object.new

def object.method
  :value
end

object.__send__(:method, **{})
=> :value

kwargs = {}

object.__send__(:method, **kwargs)
ArgumentError (wrong number of arguments (given 1, expected 0))
```

The fix would be much appreciated, as otherwise we would have to restrict RABL to `< 0.16.0`.