### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 * Support for Rails 7 (@tagliala)
 * Improvements to unit testing
-* Miscellanious other bug fixes
+* Miscellaneous other bug fixes
 
 ## 0.14.5 (May 29th, 2021)
 

--- a/fixtures/padrino_test/config/database.rb
+++ b/fixtures/padrino_test/config/database.rb
@@ -39,5 +39,5 @@ ActiveSupport.use_standard_json_time_format = true
 # if you're including raw json in an HTML page.
 ActiveSupport.escape_html_entities_in_json = false
 
-# Now we can estabilish connection with our db
+# Now we can establish connection with our db
 ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Padrino.env])

--- a/lib/rabl/renderer.rb
+++ b/lib/rabl/renderer.rb
@@ -42,7 +42,7 @@ module Rabl
     # - context_scope:
     #     Override the render context_scope to the 'context_scope' object. Defaults to self.
     #
-    # Returns: And object representing the tranformed object in the requested format.
+    # Returns: And object representing the transformed object in the requested format.
     #   e.g. json, xml, bson, plist
     def render(context_scope = nil)
       context_scope ||= options[:scope] || self

--- a/test/bson_engine_test.rb
+++ b/test/bson_engine_test.rb
@@ -85,7 +85,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }
@@ -250,7 +250,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -257,7 +257,7 @@ context "Rabl::Builder" do
       b.to_hash(@user)
     end.equivalent_to({ :user => { :name => "rabl" } })
 
-    asserts "that it does't duplicate childs with the same name as a string and symbol" do
+    asserts "that it doesn't duplicate children with the same name as a string and symbol" do
       b = builder(nil, :child => [
         { :data => { @user => "user" }, :options => { }, :block => lambda { |u| attribute :name } },
         { :data => { @user => :user }, :options => { }, :block => lambda { |u| attribute :name } }

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -312,7 +312,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }
@@ -705,7 +705,7 @@ context "Rabl::Engine" do
     end # attribute
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }

--- a/test/msgpack_engine_test.rb
+++ b/test/msgpack_engine_test.rb
@@ -87,7 +87,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }
@@ -252,7 +252,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }

--- a/test/plist_engine_test.rb
+++ b/test/plist_engine_test.rb
@@ -85,7 +85,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -93,7 +93,7 @@ context "Rabl::Engine" do
     end
 
     context "#code" do
-      asserts "that it can create an arbitraty code node" do
+      asserts "that it can create an arbitrary code node" do
         template = rabl %{
           code(:foo) { 'bar' }
         }


### PR DESCRIPTION
Found via `codespell -H`