### PR TITLE
Fix CI and test against Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,38 @@ on:
 jobs:
   test:
     name: Ruby tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        ruby-version: ['1.9.3', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
-        experimental: [false]
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        channel: ['stable']
+        os: ['ubuntu-latest']
 
         include:
-          - ruby-version: 'head'
-            experimental: true
+          # Test legacy Ruby versions on ubuntu-20.04 to avoid segmentation
+          # faults and errors with `Marshal`. Ref: ruby/setup-ruby#496
+          - ruby-version: '1.9.3'
+            channel: 'stable'
+            os: 'ubuntu-20.04'
+          - ruby-version: '2.0'
+            channel: 'stable'
+            os: 'ubuntu-20.04'
+          - ruby-version: '2.1'
+            channel: 'stable'
+            os: 'ubuntu-20.04'
+          - ruby-version: '2.2'
+            channel: 'stable'
+            os: 'ubuntu-20.04'
 
-    continue-on-error: ${{ matrix.experimental }}
+          - ruby-version: 'head'
+            channel: 'experimental'
+            os: 'ubuntu-latest'
+
+    continue-on-error: ${{ matrix.channel != 'stable' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
- Test against Ruby 3.3
- Use a string value instead of experimental boolean for improved
  readability
- Test legacy Ruby versions against ubuntu-20.04 to avoid segmentation
  faults and errors related to `Marshal`

Ref: https://github.com/ruby/setup-ruby/issues/496