### PR TITLE
Fix CI failures related to sqlite3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,11 @@ group :test do
   gem 'builder'
 
   rails_version = RUBY_VERSION =~ /\A(1|2.[01])/ ? '~> 4.0' : '>= 4.0'
+  sqlite3_version = RUBY_VERSION >= '2.5' ? '>= 1.5' : '< 1.5'
   # FIXTURES
   gem 'rack-test', :require => 'rack/test'
   gem 'activerecord', rails_version, :require => 'active_record'
-  gem 'sqlite3'
+  gem 'sqlite3', sqlite3_version
   gem 'sinatra', '>= 1.2.0'
   gem 'hashie'
   gem 'riot'


### PR DESCRIPTION
sqlite3 does not install anymore on Ruby 2.3 and 2.4 on CI.

This commit installs an older version of sqlite3 which still installs