### PR TITLE
Improve gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,16 @@ group :test do
   gem 'sqlite3', sqlite3_version
   gem 'sinatra', '>= 1.2.0'
   gem 'hashie'
-  gem 'riot'
 end
 
 group :development, :test do
+  gem 'bson', '< 2' # FIXME: Versions >= 2 make tests fail
   # gem 'debugger'
+  gem 'msgpack'
+  gem 'oj'
+  gem 'plist'
+  gem 'rake'
+  gem 'riot'
+  gem 'rr'
+  gem 'tilt'
 end

--- a/rabl.gemspec
+++ b/rabl.gemspec
@@ -22,13 +22,4 @@ Gem::Specification.new do |s|
   else
     s.add_dependency "activesupport", '>= 2.3.14'
   end
-
-  s.add_development_dependency 'riot',     '~> 0.12.3'
-  s.add_development_dependency 'rr'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'tilt'
-  s.add_development_dependency 'oj'
-  s.add_development_dependency 'msgpack',  '~> 1.0.0'
-  s.add_development_dependency 'bson',     '~> 1.7.0'
-  s.add_development_dependency 'plist'
 end


### PR DESCRIPTION
- Relax dependencies to allow newer versions
- Move development dependencies to Gemfile

This is a new best practice and will also avoid this warning:

```
A gemspec development dependency (riot, ~> 0.12.3) is being overridden by a Gemfile dependency (riot, >= 0).
This behaviour may change in the future. Please remove either of them, or make sure they both have the same requirement
```

Ref: https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdevelopmentdependencies