### PR TITLE
Improves caching lookup performance

### DIFF
--- a/lib/rabl/sources.rb
+++ b/lib/rabl/sources.rb
@@ -5,9 +5,11 @@ module Rabl
     # Returns source for a given relative file
     # fetch_source("show", :view_path => "...") => "...contents..."
     def fetch_source(file, options = {})
-      view_paths = Array(options[:view_path]) + Array(Rabl.configuration.view_paths)
+      custom_view_path = Array(options[:view_path])
 
-      Rabl.source_cache(file, view_paths) do
+      Rabl.source_cache(file, custom_view_path) do
+        view_paths = custom_view_path + Array(Rabl.configuration.view_paths)
+
         file_path = \
           if defined?(Padrino) && context_scope.respond_to?(:settings) && context_scope.respond_to?(:resolve_template)
             fetch_padrino_source(file, options)


### PR DESCRIPTION
I've been tracking down some performance issues in our codebase and found a somewhat extreme example where this block of code is eating up around 5 seconds of compute time.

The circumstances are:

1. Our `Rabl.configuration.view_paths` has over 500 paths in it
2. I'm testing a index operation that outputs data for about 3600 ActiveRecord objects
3. The Rabl main file has around 10 `extends`, and they nest even further

Even with caching enabled, it still takes nearly 5 seconds to generate all the cache keys as each `extends` allocates an array with 500+ elements and then concatenates it to generate the cache key. In this flame graph you can see `Rabl::source_cache` takes a total of 4.84 seconds in this trace and it's all down to `Array#join`

![Screenshot 2024-12-09 at 2 22 52 PM (2)](https://github.com/user-attachments/assets/9200e9a9-83a5-4ce5-8ef2-8ae4a2a56a3b)

This change removes the `Rabl.configuration.view_paths` from the path passed in to `source_cache` so that only the custom `view_path` (if specified) is considered for part of the key. As long as `Rabl.configuration.view_paths` is only configured once at application start up and not modified on the fly, this should ultimately result in the same caching key behavior but with a lot less info needed to generate each key.

After this change the same request spends just 35 ms total executing `Rabl.source_cache`.

<img width="1800" alt="Screenshot 2025-01-03 at 5 16 38 PM" src="https://github.com/user-attachments/assets/3f1d3e3b-0daf-43bb-abff-e6c36f6c1c9c" />


