### PR TITLE
Fix method from ActiveSupport not being available

### DIFF
--- a/lib/rabl.rb
+++ b/lib/rabl.rb
@@ -1,4 +1,5 @@
 require 'active_support'
+require 'active_support/core_ext/array/extract_options'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/reverse_merge'


### PR DESCRIPTION
We’re using rabl within a Sinatra app and rely on Bundler requiring all defined gems automatically and we do not require ActiveSupport or its components explicitly. We ran into an issue with `extract_options!` being undefined, because rabl itself does not require the corresponding file from ActiveSupport. This PR fixes that.