### PR TITLE
Fix undefined method replace_engine for nil:NilClass

### DIFF
--- a/lib/rabl/multi_builder.rb
+++ b/lib/rabl/multi_builder.rb
@@ -94,7 +94,7 @@ module Rabl
       @cache_results.each do |key, value|
         engine = @cache_key_to_engine[key]
         builder = @engine_to_builder[engine]
-        builder.replace_engine(engine, value) if builder && value
+        builder.replace_engine(engine, value) if value && engine && builder
       end
     end
   end

--- a/lib/rabl/multi_builder.rb
+++ b/lib/rabl/multi_builder.rb
@@ -94,7 +94,7 @@ module Rabl
       @cache_results.each do |key, value|
         engine = @cache_key_to_engine[key]
         builder = @engine_to_builder[engine]
-        builder.replace_engine(engine, value) if value
+        builder.replace_engine(engine, value) if builder && value
       end
     end
   end

--- a/test/multi_builder_test.rb
+++ b/test/multi_builder_test.rb
@@ -67,5 +67,26 @@ context "Rabl::MultiBuilder" do
       mock(b).replace_engine(e, '{}')
       mb.send(:replace_engines_with_cache_results)
     end
+
+    asserts "does not raise an error when cache results contain unknown keys" do
+      mb = multi_builder [], {}
+      mb.instance_variable_set('@cache_key_to_engine', {})
+      mb.instance_variable_set('@engine_to_builder', {})
+      mb.instance_variable_set('@cache_results', { 'unknown_key' => '{}' })
+
+      mb.send(:replace_engines_with_cache_results)
+      true
+    end.equals(true)
+
+    asserts "does not raise an error when engine maps to nil builder" do
+      mb = multi_builder [], {}
+      e = engine User.new
+      mb.instance_variable_set('@cache_key_to_engine', { 'cache_key' => e })
+      mb.instance_variable_set('@engine_to_builder', {})
+      mb.instance_variable_set('@cache_results', { 'cache_key' => '{}' })
+
+      mb.send(:replace_engines_with_cache_results)
+      true
+    end.equals(true)
   end
 end


### PR DESCRIPTION
## Summary
- Add nil guard for `builder` in `replace_engines_with_cache_results` to prevent `NoMethodError` when `@engine_to_builder` lookup returns nil
- Fixes #784

## Test plan
- [x] Verify existing test suite passes
- [ ] Confirm the error from #784 no longer occurs when using default engine with caching enabled